### PR TITLE
Ensure duplicate Scheme-Concept links are not created

### DIFF
--- a/taxonomy-manager-rest-server/src/integrationTest/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptSchemeDaoTests.java
+++ b/taxonomy-manager-rest-server/src/integrationTest/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptSchemeDaoTests.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -53,32 +54,32 @@ public class ConceptSchemeDaoTests {
 
     @Test
     public void shouldRemoveTopConcepts() throws Exception {
-        var conceptId = createDummyConcept();
+        var conceptA = new ConceptReference(createDummyConcept(), new HashMap<>());
+        var conceptB = new ConceptReference(createDummyConcept(), new HashMap<>());
+        var conceptC = new ConceptReference(createDummyConcept(), new HashMap<>());
 
         var dao = new ConceptSchemeDao(dataSource);
         var record = new ConceptSchemeRecord(DUMMY_SCHEME_ID);
-        var topConcepts = List.of(new ConceptReference(conceptId, Map.of()));
 
-        dao.storeDataSet(new ConceptSchemeDataSet(record, topConcepts));
-        dao.storeDataSet(new ConceptSchemeDataSet(record, List.of()));
+        dao.storeDataSet(new ConceptSchemeDataSet(record, List.of(conceptA, conceptB)));
+        dao.storeDataSet(new ConceptSchemeDataSet(record, List.of(conceptB, conceptC)));
 
         var updatedDataset = dao.loadDataSet(DUMMY_SCHEME_ID);
 
-        assertEquals(List.of(), updatedDataset.getTopConcepts());
+        assertEquals(List.of(conceptB, conceptC), updatedDataset.getTopConcepts());
     }
 
-
     private UUID createDummyConcept() throws SQLException {
+        UUID uuid = UUID.randomUUID();
         try (var conn = dataSource.getConnection();
              var stmt = conn.prepareStatement("INSERT INTO skos_concept (uuid) VALUES (?)")) {
 
-            stmt.setObject(1, DUMMY_CONCEPT_ID, Types.OTHER);
+            stmt.setObject(1, uuid, Types.OTHER);
             assumeTrue(stmt.executeUpdate() > 0);
         }
 
-        return DUMMY_CONCEPT_ID;
+        return uuid;
     }
 
-    private static final UUID DUMMY_CONCEPT_ID = UUID.fromString("f0ea2717-1114-46f4-bc51-a25985571a01");
     private static final UUID DUMMY_SCHEME_ID = UUID.fromString("3828f4e5-ad0d-402c-978a-e2b9939332c7");
 }

--- a/taxonomy-manager-rest-server/src/main/resources/db/migration/V2__taxman.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/migration/V2__taxman.sql
@@ -45,6 +45,7 @@ CREATE TABLE skos_concept_scheme_concept
     concept_id        bigint references skos_concept (id),
     is_top_concept    boolean
 );
+CREATE UNIQUE INDEX ON skos_concept_scheme_concept(concept_scheme_id, concept_id);
 
 
 CREATE TABLE skos_concept_semantic_relation

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__update_concept_scheme_top_concepts.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__update_concept_scheme_top_concepts.sql
@@ -1,14 +1,11 @@
-DROP PROCEDURE IF EXISTS update_concept_scheme_top_concepts(uuid, uuid[]);
+DROP PROCEDURE IF EXISTS update_concept_scheme_top_concepts;
 CREATE OR REPLACE PROCEDURE update_concept_scheme_top_concepts(_uuid uuid,
                                                                _concept_uuids uuid[])
     LANGUAGE SQL AS
 $$
--- First, delete all records associated with this scheme
-DELETE FROM skos_concept_scheme_concept USING skos_concept_scheme_concept csc
-    INNER JOIN skos_concept_scheme cs ON cs.id = csc.concept_scheme_id
-WHERE cs.uuid = _uuid;
 
--- Then, add all new entries to the database
+-- First, add all new entries to the database, ignoring items that are already there.
+
 INSERT INTO skos_concept_scheme_concept (concept_id, concept_scheme_id, is_top_concept)
 SELECT c.id,
     cs.id,
@@ -17,5 +14,22 @@ FROM unnest(_concept_uuids) concept_uuid
     INNER JOIN skos_concept c
         ON c.uuid = concept_uuid
     INNER JOIN skos_concept_scheme cs
-        ON cs.uuid = _uuid;
+        ON cs.uuid = _uuid
+ON CONFLICT DO NOTHING;
+
+-- Then, delete any existing entries that were not in the list provided.
+DELETE FROM skos_concept_scheme_concept USING skos_concept_scheme_concept csc
+    INNER JOIN skos_concept c
+        ON c.id = csc.concept_id
+
+    INNER JOIN skos_concept_scheme cs
+        ON cs.id = csc.concept_scheme_id
+
+    LEFT OUTER JOIN unnest(_concept_uuids) concept_uuid
+        ON concept_uuid = c.uuid
+WHERE skos_concept_scheme_concept.concept_scheme_id = csc.concept_scheme_id
+  AND skos_concept_scheme_concept.concept_id = csc.concept_id
+  AND skos_concept_scheme_concept.is_top_concept = true
+  AND concept_uuid IS NULL;
+
 $$;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__update_concept_scheme_top_concepts.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__update_concept_scheme_top_concepts.sql
@@ -1,11 +1,14 @@
-DROP PROCEDURE IF EXISTS update_concept_scheme_top_concepts;
+DROP PROCEDURE IF EXISTS update_concept_scheme_top_concepts(uuid, uuid[]);
 CREATE OR REPLACE PROCEDURE update_concept_scheme_top_concepts(_uuid uuid,
                                                                _concept_uuids uuid[])
     LANGUAGE SQL AS
 $$
+-- First, delete all records associated with this scheme
+DELETE FROM skos_concept_scheme_concept USING skos_concept_scheme_concept csc
+    INNER JOIN skos_concept_scheme cs ON cs.id = csc.concept_scheme_id
+WHERE cs.uuid = _uuid;
 
--- First, add all new entries to the database, ignoring items that are already there.
-
+-- Then, add all new entries to the database
 INSERT INTO skos_concept_scheme_concept (concept_id, concept_scheme_id, is_top_concept)
 SELECT c.id,
     cs.id,
@@ -14,22 +17,5 @@ FROM unnest(_concept_uuids) concept_uuid
     INNER JOIN skos_concept c
         ON c.uuid = concept_uuid
     INNER JOIN skos_concept_scheme cs
-        ON cs.uuid = _uuid
-ON CONFLICT DO NOTHING;
-
--- Then, delete any existing entries that were not in the list provided.
-DELETE FROM skos_concept_scheme_concept USING skos_concept_scheme_concept csc
-    INNER JOIN skos_concept c
-        ON c.id = csc.concept_id
-
-    INNER JOIN skos_concept_scheme cs
-        ON cs.id = csc.concept_scheme_id
-
-    LEFT OUTER JOIN unnest(_concept_uuids) concept_uuid
-        ON concept_uuid = c.uuid
-WHERE skos_concept_scheme_concept.concept_scheme_id = csc.concept_scheme_id
-  AND skos_concept_scheme_concept.concept_id = csc.concept_id
-  AND skos_concept_scheme_concept.is_top_concept = true
-  AND concept_uuid IS NULL;
-
+        ON cs.uuid = _uuid;
 $$;


### PR DESCRIPTION
Previously if a concept scheme had top concepts A and B, then an update was pushed to remove A and add C, a duplicate entry was created for B. This was because we were relying on a conflict resolution strategy to prevent the duplicate from being added despite there not being any constraints that could trigger a conflict. This change prevents the duplicate from being added by overwriting the list of associated concepts instead of attempting to detect and ignore duplicates