### PR TITLE
Explicitly baseline the database on startup

### DIFF
--- a/dockerfiles/Dockerfile.jvm
+++ b/dockerfiles/Dockerfile.jvm
@@ -3,11 +3,8 @@ LABEL maintainer="Gary Tierney <gary.tierney@digirati.com>"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG OPENJDK_11_VERSION=11.0.3.7-2.el8_0
-ARG OPEN_SSL_VERSION=1.1.1-8.el8
-
 RUN microdnf install \
-       java-11-openjdk-devel-$OPENJDK_11_VERSION openssl-$OPEN_SSL_VERSION \
+       java-11-openjdk-devel openssl \
     && microdnf clean all \
     && mkdir -p /build
 
@@ -27,10 +24,8 @@ RUN ./gradlew assemble && rm -Rf "$HOME/.gradle"
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0 AS runtime
 
-ARG OPENJDK_11_VERSION=11.0.3.7-2.el8_0
-
 RUN microdnf install \
-       java-11-openjdk-headless-$OPENJDK_11_VERSION \
+       java-11-openjdk-headless \
     && microdnf clean all \
     && mkdir -p /srv/taxman/bin
 

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/lifecycle/DatabaseInitListener.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/lifecycle/DatabaseInitListener.java
@@ -13,7 +13,7 @@ public class DatabaseInitListener {
     @Inject Flyway flyway;
 
     void onStart(@Observes StartupEvent event) {
-        //flyway.baseline(); // ToDo @Gary why do we need this? It causes failures when run on a fresh DB...
+        flyway.baseline();
         flyway.migrate();
     }
 }


### PR DESCRIPTION
Re-enables baselining of the database on startup, to allow connecting to
and migrating against a database with a target schema that already
exists.

The reason this init listener exists is so baselining can be configured,
in the abscene of a `quarkus.flyway.baselineOnMigrate` option. If
baselining is not configured and the application is started with a
non-empty database then Flyway will refuse to run the migrations.

Baselining on migration should only be disabled in cases where you don't
want Flyway to create the `flyway_history` or run any of your migrations
in a database that has a non-empty schema (i.e. to prevent accidental
dataloss).