### PR TITLE
Implemented enhanced Jenkins pipeline for CI / CD

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,12 +214,12 @@ pipeline {
             }
 
             steps {
-                build job: "$DEPLOYMENT_JOB",
-                      parameters:  [
-                          [$class: 'StringParameterValue', name: 'ENVIRONMENT', value: "$DEPLOYMENT_ENV"],
-                          [$class: 'StringParameterValue', name: 'BACKEND_IMAGE_TAG', value: "${tagVersion}"]
-                      ],
-                      propagate: true
+                build job: DEPLOYMENT_JOB,
+                    parameters:  [
+                        stringParam(name: 'ENVIRONMENT', value: DEPLOYMENT_ENV),
+                        stringParam(name: 'FRONTEND_VERSION', value: tagVersion)
+                    ],
+                    propagate: true
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -217,7 +217,7 @@ pipeline {
                 build job: DEPLOYMENT_JOB,
                     parameters:  [
                         stringParam(name: 'ENVIRONMENT', value: DEPLOYMENT_ENV),
-                        stringParam(name: 'FRONTEND_VERSION', value: tagVersion)
+                        stringParam(name: 'BACKEND_IMAGE_TAG', value: tagVersion)
                     ],
                     propagate: true
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,12 +128,7 @@ pipeline {
 
         stage('build image') {
             steps {
-                script {
-                    backendImage = docker.build(IMAGE_REPOSITORY,
-                        "-f dockerfiles/Dockerfile.jvm " +
-                        "."
-                    )
-                }
+                sh 'docker build -t $IMAGE_REPOSITORY:latest -f dockerfiles/Dockerfile.jvm .'
             }
         }
 
@@ -202,14 +197,10 @@ pipeline {
             }
 
             steps {
-                script {
-                    withCredentials([usernamePassword(credentialsId: "$IMAGE_CREDS_JENKINS_ID", usernameVariable: 'IMAGE_REGISTRY_USERNAME', passwordVariable: 'IMAGE_REGISTRY_PASSWORD')]) {
-                        sh 'docker login $IMAGE_REGISTRY --username $IMAGE_REGISTRY_USERNAME --password $IMAGE_REGISTRY_PASSWORD'
-                        docker.withRegistry(IMAGE_REGISTRY) {
-                            backendImage.push(tagVersion)
-                        }
-
-                    }
+                withCredentials([usernamePassword(credentialsId: "$IMAGE_CREDS_JENKINS_ID", usernameVariable: 'IMAGE_REGISTRY_USERNAME', passwordVariable: 'IMAGE_REGISTRY_PASSWORD')]) {
+                    sh 'docker login $IMAGE_REGISTRY --username $IMAGE_REGISTRY_USERNAME --password $IMAGE_REGISTRY_PASSWORD'
+                    sh "docker tag \$IMAGE_REPOSITORY:latest \$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:${tagVersion}"
+                    sh "docker push \$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:${tagVersion}"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,9 @@ pipeline {
     }
 
     environment {
+        GIT_COMMITER_EMAIL = 'digirati-ci@digirati.com'
+        GIT_COMMITER_USERNAME = 'digirati-ci'
+        GITHUB_REPO_PATH = 'digirati-co-uk/taxonomy-manager'
         IMAGE_CREDS_JENKINS_ID = 'aks-taxman'
         IMAGE_REGISTRY = 'taxman.azurecr.io'
         IMAGE_REPOSITORY = 'backend'
@@ -21,6 +24,27 @@ pipeline {
     }
 
     stages {
+        stage('abort if release candidate tag') {
+            when {
+                tag pattern: /^\d+.\d+.\d+-.+$/, comparator: 'REGEXP'
+            }
+
+            steps {
+                script {
+                    echo 'Release candidate build detected, quietly aborting...'
+                    currentBuild.result = 'SUCCESS'
+                    return
+                }
+            }
+        }
+
+        stage('initialise git config') {
+            steps {
+                sh("git config user.email '${GIT_COMMITER_EMAIL}'")
+                sh("git config user.name '${GIT_COMMITER_USERNAME}'")
+            }
+        }
+
         stage('general linting') {
             steps {
                 sh 'pre-commit install'
@@ -106,6 +130,62 @@ pipeline {
             }
         }
 
+        stage('determine release candidate tag') {
+            when {
+                branch 'master'
+            }
+
+            steps {
+                script {
+                    def properties = readProperties(file: 'version.properties')
+                    tagVersion = "${properties.version}-${currentBuild.startTimeInMillis}.${currentBuild.number}"
+                }
+            }
+        }
+
+        stage('determine release tag') {
+            when {
+                tag pattern: /^\d+.\d+.\d+\$/, comparator: 'REGEXP'
+            }
+
+            steps {
+                script {
+                    tagVersion = sh (returnStdout: true, script: "git tag --points-at HEAD").trim()
+                }
+            }
+        }
+
+        stage('create github release') {
+            when {
+                anyOf {
+                    branch 'master'
+                    tag pattern: /\d+.\d+.\d+$/, comparator: 'REGEXP'
+                }
+            }
+
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'github-token', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+                    script {
+                        def createReleaseResponse = sh (
+                                returnStdout: true,
+                                script:
+                                        """
+                            curl -u '${GIT_USERNAME}:${GIT_PASSWORD}' \
+                                 -H 'Content-Type:application/json' \
+                                 'https://api.github.com/repos/${GITHUB_REPO_PATH}/releases' \
+                                 -d '{
+                                         "tag_name": "${tagVersion}",
+                                         "target_commitish": "$GIT_COMMIT",
+                                         "name": "${tagVersion}",
+                                         "prerelease": ${tagVersion ==~ /^\d+.\d+.\d+-.+$/}
+                                     }'
+                            """
+                        )
+                    }
+                }
+            }
+        }
+
         stage('push image') {
             when {
                 branch "master"
@@ -117,10 +197,8 @@ pipeline {
                 }
 
                 script {
-                    def properties = readProperties(file: 'version.properties')
-                    version = "${properties.version}-${currentBuild.startTimeInMillis}.${currentBuild.number}"
                     def images = [
-                        "\$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:$version",
+                        "\$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:$tagVersion",
                         "\$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:latest"
                     ]
 
@@ -141,7 +219,7 @@ pipeline {
                 build job: "$DEPLOYMENT_JOB",
                       parameters:  [
                           [$class: 'StringParameterValue', name: 'ENVIRONMENT', value: "$DEPLOYMENT_ENV"],
-                          [$class: 'StringParameterValue', name: 'BACKEND_IMAGE_TAG', value: "${version}"]
+                          [$class: 'StringParameterValue', name: 'BACKEND_IMAGE_TAG', value: "${tagVersion}"]
                       ],
                       propagate: true
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,7 +132,7 @@ pipeline {
 
         stage('determine release candidate tag') {
             when {
-                branch 'feature/enhanced_jenkins_pipeline'
+                branch 'master'
             }
 
             steps {
@@ -158,7 +158,7 @@ pipeline {
         stage('create github release') {
             when {
                 anyOf {
-                    branch 'feature/enhanced_jenkins_pipeline'
+                    branch 'master'
                     tag pattern: /\d+.\d+.\d+$/, comparator: 'REGEXP'
                 }
             }
@@ -189,7 +189,7 @@ pipeline {
         stage('push image') {
             when {
                 anyOf {
-                    branch 'feature/enhanced_jenkins_pipeline'
+                    branch 'master'
                     tag pattern: /\d+.\d+.\d+$/, comparator: 'REGEXP'
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,7 +127,7 @@ pipeline {
         }
 
         stage('build image') {
-            steps {
+            script {
                 backendImage = docker.build(REPOSITORY_NAME,
                     "-f dockerfiles/Dockerfile.jvm " +
                     "."
@@ -199,7 +199,7 @@ pipeline {
                 }
             }
 
-            steps {
+            script {
                 withCredentials([usernamePassword(credentialsId: "$IMAGE_CREDS_JENKINS_ID", usernameVariable: 'IMAGE_REGISTRY_USERNAME', passwordVariable: 'IMAGE_REGISTRY_PASSWORD')]) {
                     sh 'docker login $IMAGE_REGISTRY --username $IMAGE_REGISTRY_USERNAME --password $IMAGE_REGISTRY_PASSWORD'
                     docker.withRegistry(IMAGE_REGISTRY) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,11 +127,13 @@ pipeline {
         }
 
         stage('build image') {
-            script {
-                backendImage = docker.build(REPOSITORY_NAME,
-                    "-f dockerfiles/Dockerfile.jvm " +
-                    "."
-                )
+            steps {
+                script {
+                    backendImage = docker.build(REPOSITORY_NAME,
+                            "-f dockerfiles/Dockerfile.jvm " +
+                                    "."
+                    )
+                }
             }
         }
 
@@ -199,13 +201,15 @@ pipeline {
                 }
             }
 
-            script {
-                withCredentials([usernamePassword(credentialsId: "$IMAGE_CREDS_JENKINS_ID", usernameVariable: 'IMAGE_REGISTRY_USERNAME', passwordVariable: 'IMAGE_REGISTRY_PASSWORD')]) {
-                    sh 'docker login $IMAGE_REGISTRY --username $IMAGE_REGISTRY_USERNAME --password $IMAGE_REGISTRY_PASSWORD'
-                    docker.withRegistry(IMAGE_REGISTRY) {
-                        backendImage.push(tagVersion)
-                    }
+            steps {
+                script {
+                    withCredentials([usernamePassword(credentialsId: "$IMAGE_CREDS_JENKINS_ID", usernameVariable: 'IMAGE_REGISTRY_USERNAME', passwordVariable: 'IMAGE_REGISTRY_PASSWORD')]) {
+                        sh 'docker login $IMAGE_REGISTRY --username $IMAGE_REGISTRY_USERNAME --password $IMAGE_REGISTRY_PASSWORD'
+                        docker.withRegistry(IMAGE_REGISTRY) {
+                            backendImage.push(tagVersion)
+                        }
 
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,8 +128,7 @@ pipeline {
 
         stage('build image') {
             steps {
-                backendImage = docker.build(
-                    env.REPOSITORY_NAME,
+                backendImage = docker.build(REPOSITORY_NAME,
                     "-f dockerfiles/Dockerfile.jvm " +
                     "."
                 )
@@ -203,9 +202,10 @@ pipeline {
             steps {
                 withCredentials([usernamePassword(credentialsId: "$IMAGE_CREDS_JENKINS_ID", usernameVariable: 'IMAGE_REGISTRY_USERNAME', passwordVariable: 'IMAGE_REGISTRY_PASSWORD')]) {
                     sh 'docker login $IMAGE_REGISTRY --username $IMAGE_REGISTRY_USERNAME --password $IMAGE_REGISTRY_PASSWORD'
-                    docker.withRegistry(env.$IMAGE_REGISTRY) {
+                    docker.withRegistry(IMAGE_REGISTRY) {
                         backendImage.push(tagVersion)
                     }
+
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,9 +129,9 @@ pipeline {
         stage('build image') {
             steps {
                 script {
-                    backendImage = docker.build(REPOSITORY_NAME,
-                            "-f dockerfiles/Dockerfile.jvm " +
-                                    "."
+                    backendImage = docker.build(IMAGE_REPOSITORY,
+                        "-f dockerfiles/Dockerfile.jvm " +
+                        "."
                     )
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,7 +132,7 @@ pipeline {
 
         stage('determine release candidate tag') {
             when {
-                branch 'master'
+                branch 'feature/enhanced_jenkins_pipeline'
             }
 
             steps {
@@ -158,7 +158,7 @@ pipeline {
         stage('create github release') {
             when {
                 anyOf {
-                    branch 'master'
+                    branch 'feature/enhanced_jenkins_pipeline'
                     tag pattern: /\d+.\d+.\d+$/, comparator: 'REGEXP'
                 }
             }
@@ -188,24 +188,17 @@ pipeline {
 
         stage('push image') {
             when {
-                branch "master"
+                anyOf {
+                    branch 'feature/enhanced_jenkins_pipeline'
+                    tag pattern: /\d+.\d+.\d+$/, comparator: 'REGEXP'
+                }
             }
 
             steps {
                 withCredentials([usernamePassword(credentialsId: "$IMAGE_CREDS_JENKINS_ID", usernameVariable: 'IMAGE_REGISTRY_USERNAME', passwordVariable: 'IMAGE_REGISTRY_PASSWORD')]) {
                     sh 'docker login $IMAGE_REGISTRY --username $IMAGE_REGISTRY_USERNAME --password $IMAGE_REGISTRY_PASSWORD'
-                }
-
-                script {
-                    def images = [
-                        "\$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:$tagVersion",
-                        "\$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:latest"
-                    ]
-
-                    for (String image : images) {
-                        sh "docker tag \$IMAGE_REPOSITORY:latest $image"
-                        sh "docker push $image"
-                    }
+                    sh "docker tag \$IMAGE_REPOSITORY:latest \$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:$tagVersion"
+                    sh "docker push \$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:$tagVersion"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,7 +207,10 @@ pipeline {
 
         stage('deploy image') {
             when {
-                branch "master"
+                anyOf {
+                    branch 'master'
+                    tag pattern: RELEASE_TAG_REGEX, comparator: 'REGEXP'
+                }
             }
 
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
 
     environment {
         RELEASE_TAG_REGEX = /^\d+\.\d+\.\d+$/
-        RC_TAG_REGEX = /^\d+.\d+.\d+-.+$/
+        RC_TAG_REGEX = /^\d+\.\d+\.\d+-.+$/
         GIT_COMMITER_EMAIL = 'digirati-ci@digirati.com'
         GIT_COMMITER_USERNAME = 'digirati-ci'
         GITHUB_REPO_PATH = 'digirati-co-uk/taxonomy-manager'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
 
         stage('determine release tag') {
             when {
-                tag pattern: /^\d+.\d+.\d+\$/, comparator: 'REGEXP'
+                tag pattern: /^\d+.\d+.\d+$/, comparator: 'REGEXP'
             }
 
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,8 @@ pipeline {
     }
 
     environment {
+        RELEASE_TAG_REGEX = /^\d+\.\d+\.\d+$/
+        RC_TAG_REGEX = /^\d+.\d+.\d+-.+$/
         GIT_COMMITER_EMAIL = 'digirati-ci@digirati.com'
         GIT_COMMITER_USERNAME = 'digirati-ci'
         GITHUB_REPO_PATH = 'digirati-co-uk/taxonomy-manager'
@@ -26,7 +28,7 @@ pipeline {
     stages {
         stage('abort if release candidate tag') {
             when {
-                tag pattern: /^\d+.\d+.\d+-.+$/, comparator: 'REGEXP'
+                tag pattern: RC_TAG_REGEX, comparator: 'REGEXP'
             }
 
             steps {
@@ -145,7 +147,7 @@ pipeline {
 
         stage('determine release tag') {
             when {
-                tag pattern: /^\d+.\d+.\d+$/, comparator: 'REGEXP'
+                tag pattern: RELEASE_TAG_REGEX, comparator: 'REGEXP'
             }
 
             steps {
@@ -159,7 +161,7 @@ pipeline {
             when {
                 anyOf {
                     branch 'master'
-                    tag pattern: /\d+.\d+.\d+$/, comparator: 'REGEXP'
+                    tag pattern: RELEASE_TAG_REGEX, comparator: 'REGEXP'
                 }
             }
 
@@ -177,7 +179,7 @@ pipeline {
                                          "tag_name": "${tagVersion}",
                                          "target_commitish": "$GIT_COMMIT",
                                          "name": "${tagVersion}",
-                                         "prerelease": ${tagVersion ==~ /^\d+.\d+.\d+-.+$/}
+                                         "prerelease": ${tagVersion ==~ RC_TAG_REGEX}
                                      }'
                             """
                         )
@@ -190,7 +192,7 @@ pipeline {
             when {
                 anyOf {
                     branch 'master'
-                    tag pattern: /\d+.\d+.\d+$/, comparator: 'REGEXP'
+                    tag pattern: RELEASE_TAG_REGEX, comparator: 'REGEXP'
                 }
             }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,8 +197,8 @@ pipeline {
             steps {
                 withCredentials([usernamePassword(credentialsId: "$IMAGE_CREDS_JENKINS_ID", usernameVariable: 'IMAGE_REGISTRY_USERNAME', passwordVariable: 'IMAGE_REGISTRY_PASSWORD')]) {
                     sh 'docker login $IMAGE_REGISTRY --username $IMAGE_REGISTRY_USERNAME --password $IMAGE_REGISTRY_PASSWORD'
-                    sh "docker tag \$IMAGE_REPOSITORY:latest \$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:$tagVersion"
-                    sh "docker push \$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:$tagVersion"
+                    sh "docker tag \$IMAGE_REPOSITORY:latest \$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:${tagVersion}"
+                    sh "docker push \$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:${tagVersion}"
                 }
             }
         }


### PR DESCRIPTION
This pipeline builds upon the existing pipeline by adding the following:

- All pushes to the `master` branch now result in a release candidate tag being automatically created, along with a corresponding release in GitHub, and deployment to `DEV`.
- Running a release tag through the pipeline results in creation of the corresponding release in GitHub, and deployment to `DEV`.
- All other branches (e.g. feature, bugfix, chore, etc) result in the usual set of test and build steps, but with no tagging, release creation or deployment taking place.

Branches, PR's and tag builds can be re-run at any time via the Jenkins UI. Any version of the backend can be deployed to any environment via the `taxonomy-manager` build job, by running the job with the relevant parameters.