### PR TITLE
Updated Jenkins build pipeline for automatic image tags from all branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ node {
     stage('push image') {
         withCredentials([usernamePassword(credentialsId: "aks-taxman", usernameVariable: 'registryUsername', passwordVariable: 'registryPassword')]) {
             buildImage.inside("-v /var/run/docker.sock:/var/run/docker.sock") {
-                pushImage(config.registryUrl, registryUsername, registryPassword, tagVersion)
+                pushImage(config.registryUrl, registryUsername, registryPassword, config.repositoryName, tagVersion)
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,11 +156,11 @@ def genericCodeAnalysis() {
 }
 
 def pullRequestCodeAnalysis() {
-    def branchName = env.GIT_BRANCH.replaceAll("origin/", "")
+    def branchName = env.BRANCH_NAME
     def changeId = env.CHANGE_ID
     def workspace = env.WORKSPACE
 
-    sh "$workspace/gradlew -Pci=true sonarqube -Dsonar.pullrequest.branch=$branchName -Dsonar.pullrequest.key=$changeId"
+    sh "$workspace/gradlew -Pci=true sonarqube -Dsonar.pullrequest.branch=${branchName} -Dsonar.pullrequest.key=${changeId}"
 }
 
 def mainlineCodeAnalysis() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,232 +1,205 @@
-pipeline {
-    agent {
-        dockerfile {
-            dir 'dockerfiles'
-            filename 'Dockerfile.build'
-            args '-v /var/run/docker.sock:/var/run/docker.sock'
+node {
+
+    def config = [
+        tagCommit: isMasterBuild(),
+        deployImage: isMasterBuild() || env.TAG_NAME,
+        gitCommiterEmail: 'digirati-ci@digirati.com',
+        gitCommiterUsername: 'digirati-ci',
+        registryUrl: "https://taxman.azurecr.io",
+        repositoryName: "backend",
+        deploymentJob: '../digirati-taxonomy-manager-infra/master',
+        deploymentEnv: 'dev'
+    ]
+
+    stage('checkout scm') {
+        checkoutScm()
+    }
+
+    def buildImage
+
+    stage('build build image') {
+        buildImage = buildBuildImage()
+    }
+
+    stage('initialise git config') {
+        buildImage.inside("-v /var/run/docker.sock:/var/run/docker.sock") {
+            initialiseGitConfig(config.gitCommiterEmail, config.gitCommiterUsername)
         }
     }
 
-    environment {
-        RELEASE_TAG_REGEX = /^\d+\.\d+\.\d+$/
-        RC_TAG_REGEX = /^\d+\.\d+\.\d+-.+$/
-        GIT_COMMITER_EMAIL = 'digirati-ci@digirati.com'
-        GIT_COMMITER_USERNAME = 'digirati-ci'
-        GITHUB_REPO_PATH = 'digirati-co-uk/taxonomy-manager'
-        IMAGE_CREDS_JENKINS_ID = 'aks-taxman'
-        IMAGE_REGISTRY = 'taxman.azurecr.io'
-        IMAGE_REPOSITORY = 'backend'
-        DEPLOYMENT_JOB = '../digirati-taxonomy-manager-infra/master'
-        DEPLOYMENT_ENV = 'dev'
+    stage('general linting') {
+        buildImage.inside("-v /var/run/docker.sock:/var/run/docker.sock") {
+            generalLinting()
+        }
     }
 
-    options {
-        ansiColor('xterm')
-        timestamps()
+    stage('dockerfile linting') {
+        docker.image('hadolint/hadolint:latest-debian').inside {
+            dockerfileLinting()
+        }
     }
 
-    stages {
-        stage('abort if release candidate tag') {
-            when {
-                tag pattern: RC_TAG_REGEX, comparator: 'REGEXP'
-            }
-
-            steps {
-                script {
-                    echo 'Release candidate build detected, quietly aborting...'
-                    currentBuild.result = 'SUCCESS'
-                    return
-                }
-            }
+    stage('build modules') {
+        buildImage.inside("-v /var/run/docker.sock:/var/run/docker.sock") {
+            buildModules()
         }
+    }
 
-        stage('initialise git config') {
-            steps {
-                sh("git config user.email '${GIT_COMMITER_EMAIL}'")
-                sh("git config user.name '${GIT_COMMITER_USERNAME}'")
-            }
+    stage('generic code analysis') {
+        buildImage.inside("-v /var/run/docker.sock:/var/run/docker.sock") {
+            genericCodeAnalysis()
         }
+    }
 
-        stage('general linting') {
-            steps {
-                sh 'pre-commit install'
-                sh 'pre-commit run --all-files --verbose'
-            }
-        }
-
-        stage('dockerfile linting') {
-            agent {
-                docker {
-                    image 'hadolint/hadolint:latest-debian'
-                }
-            }
-            steps {
-                sh 'hadolint dockerfiles/* | tee -a hadolint_lint.txt'
-            }
-            post {
-                always {
-                    archiveArtifacts 'hadolint_lint.txt'
-                }
-            }
-        }
-
-        stage('build modules') {
-            steps {
-                script {
-                    def workspace = env.WORKSPACE
-                    sh "$workspace/gradlew -Pci=true clean generateTestKeyPair assemble check"
-                }
-            }
-        }
-
-        stage("generic code analysis") {
-            steps {
-                script {
-                    def spotbugs = scanForIssues tool: [$class: 'SpotBugs', pattern: '**/build/reports/spotbugs/*.xml']
-                    def checkstyle = scanForIssues tool: [$class: 'CheckStyle', pattern: '**/build/reports/checkstyle/*.xml']
-                    def javac = scanForIssues tool: [$class: 'Java']
-
-                    publishIssues issues: [javac]
-                    publishIssues issues: [spotbugs]
-                    publishIssues issues: [checkstyle]
-                }
-            }
-        }
-
+    if (env.CHANGE_ID != null) {
         stage('pull request code analysis') {
-            when {
-                expression { env.CHANGE_ID != null }
-            }
-
-            steps {
-                withSonarQubeEnv('default') {
-                    script {
-                        def branchName = env.GIT_BRANCH.replaceAll("origin/", "")
-                        def changeId = env.CHANGE_ID
-                        def workspace = env.WORKSPACE
-
-                        sh "$workspace/gradlew -Pci=true sonarqube -Dsonar.pullrequest.branch=$branchName -Dsonar.pullrequest.key=$changeId"
-                    }
+            withSonarQubeEnv('default') {
+                buildImage.inside("-v /var/run/docker.sock:/var/run/docker.sock") {
+                    pullRequestCodeAnalysis()
                 }
             }
         }
+    }
 
-        stage ('mainline code analysis') {
-            when {
-                branch "master"
-            }
-
-            steps {
-                withSonarQubeEnv('default') {
-                    script {
-                        def workspace = env.WORKSPACE
-                        sh "$workspace/gradlew -Pci=true sonarqube"
-                    }
+    if (isMasterBuild()) {
+        stage('mainline code analysis') {
+            withSonarQubeEnv('default') {
+                buildImage.inside("-v /var/run/docker.sock:/var/run/docker.sock") {
+                    mainlineCodeAnalysis()
                 }
             }
         }
+    }
 
-        stage('build image') {
-            steps {
-                sh 'docker build -t $IMAGE_REPOSITORY:latest -f dockerfiles/Dockerfile.jvm .'
+    def backendImage
+
+    stage('build backend image') {
+        buildImage.inside("-v /var/run/docker.sock:/var/run/docker.sock") {
+            backendImage = buildBackendImage(config.repositoryName)
+        }
+    }
+
+    def tagVersion = fetchTagVersion()
+
+    if (config.tagCommit) {
+        stage('create git tag') {
+            buildImage.inside("-v /var/run/docker.sock:/var/run/docker.sock") {
+                createGitTag(tagVersion)
             }
         }
+    }
 
-        stage('determine release candidate tag') {
-            when {
-                branch 'master'
-            }
-
-            steps {
-                script {
-                    def properties = readProperties(file: 'version.properties')
-                    tagVersion = "${properties.version}-${currentBuild.startTimeInMillis}.${currentBuild.number}"
-                }
+    stage('push image') {
+        withCredentials([usernamePassword(credentialsId: "aks-taxman", usernameVariable: 'registryUsername', passwordVariable: 'registryPassword')]) {
+            buildImage.inside("-v /var/run/docker.sock:/var/run/docker.sock") {
+                pushImage(config.registryUrl, registryUsername, registryPassword, backendImage, tagVersion)
             }
         }
+    }
 
-        stage('determine release tag') {
-            when {
-                tag pattern: RELEASE_TAG_REGEX, comparator: 'REGEXP'
-            }
-
-            steps {
-                script {
-                    tagVersion = sh (returnStdout: true, script: "git tag --points-at HEAD").trim()
-                }
-            }
-        }
-
-        stage('create github release') {
-            when {
-                anyOf {
-                    branch 'master'
-                    tag pattern: RELEASE_TAG_REGEX, comparator: 'REGEXP'
-                }
-            }
-
-            steps {
-                withCredentials([usernamePassword(credentialsId: 'github-token', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-                    script {
-                        def createReleaseResponse = sh (
-                                returnStdout: true,
-                                script:
-                                        """
-                            curl -u '${GIT_USERNAME}:${GIT_PASSWORD}' \
-                                 -H 'Content-Type:application/json' \
-                                 'https://api.github.com/repos/${GITHUB_REPO_PATH}/releases' \
-                                 -d '{
-                                         "tag_name": "${tagVersion}",
-                                         "target_commitish": "$GIT_COMMIT",
-                                         "name": "${tagVersion}",
-                                         "prerelease": ${tagVersion ==~ RC_TAG_REGEX}
-                                     }'
-                            """
-                        )
-                    }
-                }
-            }
-        }
-
-        stage('push image') {
-            when {
-                anyOf {
-                    branch 'master'
-                    tag pattern: RELEASE_TAG_REGEX, comparator: 'REGEXP'
-                }
-            }
-
-            steps {
-                withCredentials([usernamePassword(credentialsId: "$IMAGE_CREDS_JENKINS_ID", usernameVariable: 'IMAGE_REGISTRY_USERNAME', passwordVariable: 'IMAGE_REGISTRY_PASSWORD')]) {
-                    sh 'docker login $IMAGE_REGISTRY --username $IMAGE_REGISTRY_USERNAME --password $IMAGE_REGISTRY_PASSWORD'
-                    sh "docker tag \$IMAGE_REPOSITORY:latest \$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:${tagVersion}"
-                    sh "docker push \$IMAGE_REGISTRY/\$IMAGE_REPOSITORY:${tagVersion}"
-                }
-            }
-        }
-
+    if (config.deployImage) {
         stage('deploy image') {
-            when {
-                anyOf {
-                    branch 'master'
-                    tag pattern: RELEASE_TAG_REGEX, comparator: 'REGEXP'
-                }
-            }
-
-            steps {
-                build job: DEPLOYMENT_JOB,
-                    parameters:  [
-                        stringParam(name: 'ENVIRONMENT', value: DEPLOYMENT_ENV),
-                        stringParam(name: 'BACKEND_IMAGE_TAG', value: tagVersion)
-                    ],
-                    propagate: true
+            buildImage.inside("-v /var/run/docker.sock:/var/run/docker.sock") {
+                deployImage(config.deploymentJob, config.deploymentEnv, tagVersion)
             }
         }
     }
+}
 
-    post {
-        always {
-            junit '**/build/test-results/test/*.xml'
-        }
+def checkoutScm() {
+    checkout scm
+}
+
+def buildBuildImage() {
+    return docker.build("taxonomy-manager-infra-build", "-f dockerfiles/Dockerfile.build .")
+}
+
+def initialiseGitConfig(def commiterEmail, def commiterUsername) {
+    sh "git config user.email '${commiterEmail}'"
+    sh "git config user.name '${commiterUsername}'"
+}
+
+def generalLinting() {
+    sh 'pre-commit install'
+    sh 'pre-commit run --all-files --verbose'
+}
+
+def dockerfileLinting() {
+    try {
+        sh 'hadolint dockerfiles/* | tee -a hadolint_lint.txt'
     }
+    finally {
+        archiveArtifacts 'hadolint_lint.txt'
+    }
+}
+
+def buildModules() {
+    def workspace = env.WORKSPACE
+    sh "$workspace/gradlew -Pci=true clean generateTestKeyPair assemble check"
+}
+
+def genericCodeAnalysis() {
+    def spotbugs = scanForIssues tool: [$class: 'SpotBugs', pattern: '**/build/reports/spotbugs/*.xml']
+    def checkstyle = scanForIssues tool: [$class: 'CheckStyle', pattern: '**/build/reports/checkstyle/*.xml']
+    def javac = scanForIssues tool: [$class: 'Java']
+
+    publishIssues issues: [javac]
+    publishIssues issues: [spotbugs]
+    publishIssues issues: [checkstyle]
+}
+
+def pullRequestCodeAnalysis() {
+    def branchName = env.GIT_BRANCH.replaceAll("origin/", "")
+    def changeId = env.CHANGE_ID
+    def workspace = env.WORKSPACE
+
+    sh "$workspace/gradlew -Pci=true sonarqube -Dsonar.pullrequest.branch=$branchName -Dsonar.pullrequest.key=$changeId"
+}
+
+def mainlineCodeAnalysis() {
+    def workspace = env.WORKSPACE
+    sh "$workspace/gradlew -Pci=true sonarqube"
+}
+
+def buildBackendImage(def repositoryName) {
+    return docker.build(repositoryName, "-f dockerfiles/Dockerfile.jvm .")
+}
+
+def isMasterBuild() {
+    return env.BRANCH_NAME == 'master'
+}
+
+def fetchTagVersion() {
+    if (isMasterBuild()) {
+        def properties = readJSON file: 'package.json'
+        return "${properties.version}-${currentBuild.startTimeInMillis}.${currentBuild.number}"
+    }
+
+    if (env.TAG_NAME) {
+        return env.TAG_NAME
+    }
+
+    return sh(returnStdout: true, script: "echo ${env.BRANCH_NAME} | sed -e \"s/\\//-/g\"").trim()
+}
+
+def createGitTag(def tagVersion) {
+    sh "git tag -a ${tagVersion} -m 'Automatic RC tag ${tagVersion}'"
+    sh "git push origin ${tagVersion}"
+}
+
+def pushImage(def registryUrl, def registryUsername, def registryPassword, def backendImage, def tagVersion) {
+    docker.withRegistry(registryUrl) {
+        sh "docker login \"${registryUrl}\" --username \"${registryUsername}\" --password \"${registryPassword}\""
+        backendImage.push(tagVersion)
+    }
+}
+
+def deployImage(def deploymentJob, def deploymentEnv, def tagVersion) {
+    build job: deploymentJob,
+        parameters:  [
+            booleanParam(name: 'DEPLOY', value: true),
+            stringParam(name: 'ENVIRONMENT', value: deploymentEnv),
+            stringParam(name: 'BACKEND_IMAGE_TAG', value: tagVersion)
+        ],
+        propagate: true
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ node {
         deployImage: isMasterBuild() || env.TAG_NAME,
         gitCommiterEmail: 'digirati-ci@digirati.com',
         gitCommiterUsername: 'digirati-ci',
-        registryUrl: "https://taxman.azurecr.io",
+        registryUrl: "taxman.azurecr.io",
         repositoryName: "backend",
         deploymentJob: '../digirati-taxonomy-manager-infra/master',
         deploymentEnv: 'dev'
@@ -195,7 +195,7 @@ def createGitTag(def tagVersion) {
 }
 
 def pushImage(def registryUrl, def registryUsername, def registryPassword, def repositoryName, def tagVersion) {
-    sh "docker login \"${registryUrl}\" --username \"${registryUsername}\" --password \"${registryPassword}\""
+    sh "docker login \"https://${registryUrl}\" --username \"${registryUsername}\" --password \"${registryPassword}\""
     sh "docker tag \"${repositoryName}:latest\" \"${registryUrl}/${repositoryName}:${tagVersion}\""
     sh "docker push \"${registryUrl}/${repositoryName}:${tagVersion}\""
 }

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -4,25 +4,9 @@ LABEL maintainer="Daniel Grant <daniel.grant@digirati.com>"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PYTHON_VERSION=3.6.7-1~18.04
-ARG PYTHON_SETUPTOOLS_VERSION=39.0.1-2
-ARG PYTHON_PIP_VERSION=9.0.1-2.3~ubuntu1.18.04.1
-ARG SOFTWARE_PROPERTIES_COMMON_VERSION=0.96.24.32.9
-ARG PYTHON_WHEEL_VERSION=0.30.0-0.2
-ARG APT_TRANSPORT_HTTPS_VERSION=1.6.11
-ARG CURL_VERSION=7.58.0-2ubuntu3.7
-ARG GNUPG_AGENT_VERSION=2.2.4-1ubuntu1.2
-ARG GIT_VERSION=1:2.17.1-1ubuntu0.4
-ARG OPENJDK_11_JDK_HEADLESS_VERSION=11.0.3+7-1ubuntu2~18.04.1
-ARG DOCKER_CE_VERSION=5:18.09.7~3-0~ubuntu-bionic
-ARG PRE_COMMIT_VERSION=1.17.0
-
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3=$PYTHON_VERSION python3-setuptools=$PYTHON_SETUPTOOLS_VERSION \
-       python3-pip=$PYTHON_PIP_VERSION python3-wheel=$PYTHON_WHEEL_VERSION \
-       software-properties-common=$SOFTWARE_PROPERTIES_COMMON_VERSION apt-transport-https=$APT_TRANSPORT_HTTPS_VERSION \
-       curl=$CURL_VERSION gnupg-agent=$GNUPG_AGENT_VERSION git=$GIT_VERSION \
-       openjdk-11-jdk-headless=$OPENJDK_11_JDK_HEADLESS_VERSION \
+    && apt-get install -y --no-install-recommends python3 python3-setuptools python3-pip python3-wheel \
+       software-properties-common apt-transport-https curl gnupg-agent git openjdk-11-jdk-headless \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt-get update \

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -10,10 +10,10 @@ RUN apt-get update \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt-get update \
-    && apt-get install -y --no-install-recommends docker-ce=$DOCKER_CE_VERSION \
+    && apt-get install -y --no-install-recommends docker-ce \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && pip3 install pre-commit==$PRE_COMMIT_VERSION \
+    && pip3 install pre-commit \
     && useradd -m -d /home/build -s /bin/bash -u 1010 build
 
 ENV JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"


### PR DESCRIPTION
- Instead of only generating an image from `master` branch builds, an image is now built and pushed into the registry for every push (i.e. all branches).
- The downstream deployment is job only invoked for the `master` branch and tags.
- A Git release candidate tag is only cut for builds of the `master` release.