### PR TITLE
DTM-113: Deletion of Concepts, Concept Schemes and Projects

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,8 +105,8 @@ node {
 }
 
 def initialiseGitConfig(def commiterEmail, def commiterUsername) {
-  sh "git config --global user.email ${commiterEmail}"
-  sh "git config --global user.name ${commiterUsername}"
+  sh "git config user.email ${commiterEmail}"
+  sh "git config user.name ${commiterUsername}"
 }
 
 def checkoutScm() {

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/RdfModelFactory.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/RdfModelFactory.java
@@ -1,5 +1,6 @@
 package com.digirati.taxman.common.rdf;
 
+import com.digirati.taxman.common.rdf.identity.IdResolver;
 import com.google.common.collect.Iterables;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -9,6 +10,8 @@ import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +20,7 @@ import java.util.Map;
  * A factory that produces {@link RdfModel}s and {@link RdfModelBuilder}s.
  */
 public class RdfModelFactory {
+
     /**
      * Create a new {@link RdfModelBuilder} for models of the given {@code type}.
      *
@@ -40,9 +44,16 @@ public class RdfModelFactory {
         try {
             var uri = resource.getURI();
 
+            // We don't want to set source, if the URI is our URI
+            // Therefore, check for the UUID using our classes patterns
+            var uuid = IdResolver.resolve(uri, metadata.pattern);
+            var setSource = !uuid.isPresent();
+
+
+
             StmtIterator stmts = resource.listProperties();
 
-            if (!resource.hasProperty(DCTerms.source) && uri != null && stmts.hasNext()) {
+            if (setSource && !resource.hasProperty(DCTerms.source) && uri != null && stmts.hasNext()) {
                 resource.addProperty(DCTerms.source, resource);
             }
 

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/annotation/RdfContext.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/annotation/RdfContext.java
@@ -22,4 +22,6 @@ public @interface RdfContext {
      * qualified XML namespace that the prefix resolves to.
      */
     String[] value() default {};
+
+    String template() default "";
 }

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/identity/IdResolver.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/identity/IdResolver.java
@@ -1,0 +1,53 @@
+package com.digirati.taxman.common.rdf.identity;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+public class IdResolver {
+
+    // This does not need to be ever instanciated
+    private IdResolver() {
+    }
+
+    public static Optional<UUID> resolve(String uri, Pattern pattern) {
+        if (uri == null)
+            return Optional.empty();
+
+        try {
+            var parsedUri = new URI(uri);
+            return resolve(parsedUri, pattern);
+        } catch (URISyntaxException ignored) {
+            return Optional.empty();
+        }
+    }
+    public static Optional<UUID> resolve(URI uri, Pattern pattern) {
+        if (uri == null || pattern == null) {
+            return Optional.empty();
+        }
+
+        if (uri.getPath() == null) {
+            return Optional.empty();
+        }
+
+        var match = pattern.matcher(uri.getPath());
+        if (!match.find()) {
+            return Optional.empty();
+        }
+
+        var uuid = match.group(1);
+        return Optional.of(UUID.fromString(uuid));
+    }
+
+//    public static URI resolve(UUID uuid, URI uri, String template) {
+//
+//        return UriBuilder.fromUri(template)
+//                .scheme(uri.getScheme())
+//                .host(uri.getHost())
+//                .port(uri.getPort())
+//                .resolveTemplate("id", uuid.toString())
+//                .build();
+//    }
+}

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/taxonomy/ConceptModel.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/taxonomy/ConceptModel.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 @RdfType("http://www.w3.org/2004/02/skos/core#Concept")
-@RdfContext({"skos=" + SKOS.uri, "dcterms=" + DCTerms.NS})
+@RdfContext(value = {"skos=" + SKOS.uri, "dcterms=" + DCTerms.NS}, template = "/v0.1/concept/:id:")
 public final class ConceptModel implements RdfModel, PersistentModel, Concept {
 
     private final RdfModelContext context;

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/taxonomy/ConceptSchemeModel.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/taxonomy/ConceptSchemeModel.java
@@ -18,8 +18,8 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 @RdfType("http://www.w3.org/2004/02/skos/core#ConceptScheme")
-@RdfContext({"skos=" + SKOS.uri, "dcterms=" + DCTerms.NS})
-public class ConceptSchemeModel implements RdfModel, PersistentModel {
+@RdfContext(value = {"skos=" + SKOS.uri, "dcterms=" + DCTerms.NS}, template = "/v0.1/concept-scheme/:id:")
+public final class ConceptSchemeModel implements RdfModel, PersistentModel {
 
     private final RdfModelContext context;
     private UUID uuid;
@@ -40,9 +40,6 @@ public class ConceptSchemeModel implements RdfModel, PersistentModel {
 
     @Override
     public UUID getUuid() {
-        if (uuid == null) {
-            throw new IllegalStateException("Concept schemes must have a UUID.");
-        }
         return uuid;
     }
 

--- a/taxonomy-manager-rest-server/src/integrationTest/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptDaoTests.java
+++ b/taxonomy-manager-rest-server/src/integrationTest/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptDaoTests.java
@@ -60,7 +60,7 @@ public class ConceptDaoTests {
         setter.setLabels(record, expectedLabels);
         dao.storeDataSet(new ConceptDataSet(record));
 
-        var storedRecord = dao.loadDataSet(uuid).getRecord();
+        var storedRecord = dao.loadDataSet(uuid).orElseThrow().getRecord();
         var storedLabels = getter.getLabels(storedRecord);
 
         Assertions.assertEquals(expectedLabels, storedLabels);
@@ -86,7 +86,7 @@ public class ConceptDaoTests {
 
         dao.storeDataSet(new ConceptDataSet(record));
 
-        var storedRecord = dao.loadDataSet(uuid).getRecord();
+        var storedRecord = dao.loadDataSet(uuid).orElseThrow().getRecord();
         var storedLabels = getter.getLabels(storedRecord);
 
         Assertions.assertEquals(expectedLabels, storedLabels);
@@ -103,7 +103,7 @@ public class ConceptDaoTests {
         dao.storeDataSet(new ConceptDataSet(new ConceptRecord(uuidB)));
         dao.storeDataSet(new ConceptDataSet(new ConceptRecord(uuidA), relationships));
 
-        Assertions.assertEquals(relationships, dao.loadDataSet(uuidA).getRelationshipRecords());
+        Assertions.assertEquals(relationships, dao.loadDataSet(uuidA).orElseThrow().getRelationshipRecords());
     }
 
     @Test

--- a/taxonomy-manager-rest-server/src/integrationTest/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptSchemeDaoTests.java
+++ b/taxonomy-manager-rest-server/src/integrationTest/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptSchemeDaoTests.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @ExtendWith(DatabaseTestExtension.class)
@@ -39,7 +40,8 @@ public class ConceptSchemeDaoTests {
         dao.storeDataSet(dataset);
 
         var storedDataset = dao.loadDataSet(DUMMY_SCHEME_ID);
-        assertEquals(expectedTitle, storedDataset.getRecord().getTitle());
+        assertTrue(storedDataset.isPresent());
+        assertEquals(expectedTitle, storedDataset.get().getRecord().getTitle());
     }
 
     @Test
@@ -53,7 +55,8 @@ public class ConceptSchemeDaoTests {
         dao.storeDataSet(new ConceptSchemeDataSet(record, expectedTopConcepts));
 
         var storedDataset = dao.loadDataSet(DUMMY_SCHEME_ID);
-        assertEquals(expectedTopConcepts, storedDataset.getTopConcepts());
+        assertTrue(storedDataset.isPresent());
+        assertEquals(expectedTopConcepts, storedDataset.get().getTopConcepts());
     }
 
     @Test
@@ -70,7 +73,8 @@ public class ConceptSchemeDaoTests {
 
         var updatedDataset = dao.loadDataSet(DUMMY_SCHEME_ID);
 
-        assertEquals(List.of(conceptB, conceptC), updatedDataset.getTopConcepts());
+        assertTrue(updatedDataset.isPresent());
+        assertEquals(List.of(conceptB, conceptC), updatedDataset.get().getTopConcepts());
     }
 
     private UUID createDummyConcept() throws SQLException {

--- a/taxonomy-manager-rest-server/src/integrationTest/java/com/digirati/taxman/rest/server/taxonomy/storage/ProjectDaoTests.java
+++ b/taxonomy-manager-rest-server/src/integrationTest/java/com/digirati/taxman/rest/server/taxonomy/storage/ProjectDaoTests.java
@@ -11,10 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import static org.junit.Assert.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -36,10 +33,11 @@ class ProjectDaoTests {
 
         // When
         dao.storeDataSet(new ProjectDataSet(record, new ArrayList<>()));
-        ProjectDataSet retrieved = dao.loadDataSet("test-project");
+        Optional<ProjectDataSet> retrieved = dao.loadDataSet("test-project");
 
         // Then
-        assertEquals(title, retrieved.getProject().getTitle());
+        assertTrue(retrieved.isPresent());
+        assertEquals(title, retrieved.get().getProject().getTitle());
     }
 
     @Test
@@ -60,10 +58,11 @@ class ProjectDaoTests {
 
         // When
         dao.storeDataSet(project);
-        ProjectDataSet retrieved = dao.loadDataSet("test-project");
+        Optional<ProjectDataSet> retrieved = dao.loadDataSet("test-project");
 
         // Then
-        assertEquals(schemes, retrieved.getConceptSchemes());
+        assertTrue(retrieved.isPresent());
+        assertEquals(schemes, retrieved.get().getConceptSchemes());
     }
 
     @Test
@@ -88,10 +87,11 @@ class ProjectDaoTests {
 
         // When
         dao.storeDataSet(updateProject);
-        ProjectDataSet retrieved = dao.loadDataSet("test-project");
+        Optional<ProjectDataSet> retrieved = dao.loadDataSet("test-project");
 
         // Then
-        assertEquals(updatedSchemeList, retrieved.getConceptSchemes());
+        assertTrue(retrieved.isPresent());
+        assertEquals(updatedSchemeList, retrieved.get().getConceptSchemes());
     }
 
     @Test

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/ServerConceptResource.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/ServerConceptResource.java
@@ -35,7 +35,11 @@ public class ServerConceptResource implements ConceptResource {
     public Response getConcept(@BeanParam ConceptPath params) {
         var model = concepts.find(params.getUuid());
 
-        return Response.ok(model).build();
+        if (model.isPresent()) {
+            return Response.ok(model.get()).build();
+        } else {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
     }
 
     @Override

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/ServerConceptResource.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/ServerConceptResource.java
@@ -2,7 +2,6 @@ package com.digirati.taxman.rest.server;
 
 import com.digirati.taxman.common.taxonomy.CollectionModel;
 import com.digirati.taxman.common.taxonomy.ConceptModel;
-import com.digirati.taxman.common.taxonomy.ConceptRelationshipType;
 import com.digirati.taxman.rest.server.taxonomy.ConceptCollectionModelRepository;
 import com.digirati.taxman.rest.server.taxonomy.ConceptModelRepository;
 import com.digirati.taxman.rest.taxonomy.ConceptPath;
@@ -61,6 +60,13 @@ public class ServerConceptResource implements ConceptResource {
     public Response updateConcept(@BeanParam ConceptPath params, @Valid ConceptModel model) {
         model.setUuid(params.getUuid());
         concepts.update(model);
+
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response deleteConcept(ConceptPath params) {
+        concepts.delete(params.getUuid());
 
         return Response.noContent().build();
     }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/ServerConceptSchemeResource.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/ServerConceptSchemeResource.java
@@ -32,7 +32,11 @@ public class ServerConceptSchemeResource implements ConceptSchemeResource {
     public Response getConceptScheme(ConceptSchemePath params) {
         var model = conceptSchemes.find(params.getUuid());
 
-        return Response.ok(model).build();
+        if (model.isPresent()) {
+            return Response.ok(model.get()).build();
+        } else {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
     }
 
     @Override

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/ServerConceptSchemeResource.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/ServerConceptSchemeResource.java
@@ -42,4 +42,11 @@ public class ServerConceptSchemeResource implements ConceptSchemeResource {
 
         return Response.noContent().build();
     }
+
+    @Override
+    public Response deleteConceptScheme(ConceptSchemePath params) {
+        conceptSchemes.delete(params.getUuid());
+
+        return Response.noContent().build();
+    }
 }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/ServerProjectResource.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/ServerProjectResource.java
@@ -36,4 +36,11 @@ public class ServerProjectResource implements ProjectResource {
         projectModelRepository.update(projectPath.getProjectSlug(), project);
         return Response.noContent().build();
     }
+
+    @Override
+    public Response deleteProject(ProjectPath projectPath) {
+        projectModelRepository.delete(projectPath.getProjectSlug());
+
+        return Response.noContent().build();
+    }
 }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/ServerProjectResource.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/ServerProjectResource.java
@@ -28,7 +28,12 @@ public class ServerProjectResource implements ProjectResource {
 
     @Override
     public Response getProject(ProjectPath projectPath) {
-        return Response.ok(projectModelRepository.find(projectPath.getProjectSlug())).build();
+        var model = projectModelRepository.find(projectPath.getProjectSlug());
+        if (model.isPresent()) {
+            return Response.ok(model.get()).build();
+        } else {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
     }
 
     @Override

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/event/ConceptEvent.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/event/ConceptEvent.java
@@ -7,42 +7,49 @@ import com.digirati.taxman.common.taxonomy.ConceptModel;
  */
 public class ConceptEvent {
 
-    public static ConceptEvent deleted(ConceptModel concept) {
-        return new ConceptEvent(Type.DELETED, concept);
-    }
-
     private final Type type;
-
+    private final ConceptModel previous;
     private final ConceptModel concept;
 
-    public static ConceptEvent created(ConceptModel concept) {
-        return new ConceptEvent(Type.CREATED, concept);
+    private ConceptEvent(Type type, ConceptModel concept, ConceptModel previous) {
+        this.type = type;
+        this.concept = concept;
+        this.previous = previous;
     }
 
-    public static ConceptEvent updated(ConceptModel concept) {
-        return new ConceptEvent(Type.UPDATED, concept);
+    public static ConceptEvent deleted(ConceptModel concept) {
+        return new ConceptEvent(Type.DELETED, null, concept);
+    }
+
+    public static ConceptEvent created(ConceptModel concept) {
+        return new ConceptEvent(Type.CREATED, concept, null);
+    }
+
+    public static ConceptEvent updated(ConceptModel concept, ConceptModel existing) {
+        return new ConceptEvent(
+                existing == null ? Type.CREATED : Type.UPDATED,
+                concept, existing);
     }
 
     public Type getType() {
         return type;
     }
 
-    private ConceptEvent(Type type, ConceptModel concept) {
-        this.type = type;
-        this.concept = concept;
-    }
-
     public ConceptModel getConcept() {
         return concept;
+    }
+
+    public ConceptModel getPrevious() {
+        return previous;
+    }
+
+    public boolean isNew() {
+        return Type.CREATED == type;
     }
 
     public enum Type {
         CREATED,
         UPDATED,
         DELETED
-    }
-
-    public boolean isNew() {
-        return Type.CREATED == type;
     }
 }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/event/ConceptEvent.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/event/ConceptEvent.java
@@ -7,9 +7,8 @@ import com.digirati.taxman.common.taxonomy.ConceptModel;
  */
 public class ConceptEvent {
 
-    private enum Type {
-        CREATED,
-        UPDATED
+    public static ConceptEvent deleted(ConceptModel concept) {
+        return new ConceptEvent(Type.DELETED, concept);
     }
 
     private final Type type;
@@ -22,6 +21,10 @@ public class ConceptEvent {
 
     public static ConceptEvent updated(ConceptModel concept) {
         return new ConceptEvent(Type.UPDATED, concept);
+    }
+
+    public Type getType() {
+        return type;
     }
 
     private ConceptEvent(Type type, ConceptModel concept) {

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/event/ConceptEvent.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/event/ConceptEvent.java
@@ -36,6 +36,12 @@ public class ConceptEvent {
         return concept;
     }
 
+    public enum Type {
+        CREATED,
+        UPDATED,
+        DELETED
+    }
+
     public boolean isNew() {
         return Type.CREATED == type;
     }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/event/ConceptEventListener.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/event/ConceptEventListener.java
@@ -25,23 +25,25 @@ public class ConceptEventListener {
     TermIndex<UUID> index;
 
     @Subscribe
-    public void ConceptChangeEvent(ConceptEvent conceptEvent) {
-        if (conceptEvent.getPrevious() != null)
-            Remove(conceptEvent.getPrevious());
+    public void conceptChangeEvent(ConceptEvent conceptEvent) {
+        if (conceptEvent.getPrevious() != null) {
+            remove(conceptEvent.getPrevious());
+        }
 
-        if (conceptEvent.getConcept() != null)
-            Add(conceptEvent.getConcept());
+        if (conceptEvent.getConcept() != null) {
+            add(conceptEvent.getConcept());
+        }
     }
 
-    private void Add(ConceptModel concept) {
-        ConsumeLabels(concept, index::add);
+    private void add(ConceptModel concept) {
+        consumeLabels(concept, index::add);
     }
 
-    private void Remove(ConceptModel previous) {
-        ConsumeLabels(previous, index::remove);
+    private void remove(ConceptModel previous) {
+        consumeLabels(previous, index::remove);
     }
 
-    private void ConsumeLabels(ConceptModel concept, BiConsumer<UUID, String> consumer) {
+    private void consumeLabels(ConceptModel concept, BiConsumer<UUID, String> consumer) {
         var labelExtractor = new ConceptLabelExtractor(concept);
 
         labelExtractor.extractTo((property, literal) -> {

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/event/ConceptEventListener.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/event/ConceptEventListener.java
@@ -1,10 +1,15 @@
 package com.digirati.taxman.rest.server.infrastructure.event;
 
 import com.digirati.taxman.analysis.index.TermIndex;
+import com.digirati.taxman.common.taxonomy.ConceptLabelExtractor;
+import com.google.common.eventbus.Subscribe;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.util.Collection;
 import java.util.UUID;
+import java.util.function.BiConsumer;
 
 /**
  * Listener to respond to changes in the state of a concept.
@@ -12,7 +17,39 @@ import java.util.UUID;
 @ApplicationScoped
 public class ConceptEventListener {
 
+    @ConfigProperty(name = "taxman.analysis.default-lang.key", defaultValue = "en")
+    String defaultLanguageKey;
+
     @Inject
     TermIndex<UUID> index;
 
+    @Subscribe
+    public void ConceptChangeEvent(ConceptEvent conceptEvent) {
+        UUID uuid = conceptEvent.getConcept().getUuid();
+
+        BiConsumer<UUID, String> consumer = null;
+        switch (conceptEvent.getType()) {
+
+            case CREATED:
+                //consumer = index::add;
+                break;
+            case UPDATED:
+                // ???
+                break;
+            case DELETED:
+                consumer = index::remove;
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + conceptEvent.getType());
+        }
+
+        if (consumer == null) return;
+        final BiConsumer<UUID, String> finalConsumer = consumer;
+
+        var labelExtractor = new ConceptLabelExtractor(conceptEvent.getConcept());
+        labelExtractor.extractTo((property, literal) -> {
+            Collection<String> values = literal.get(defaultLanguageKey);
+            values.forEach(value -> finalConsumer.accept(uuid, value));
+        });
+    }
 }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/management/ProjectModelRepository.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/management/ProjectModelRepository.java
@@ -75,4 +75,8 @@ public class ProjectModelRepository {
         ProjectDataSet dataSet = projectMapper.map(slug, project);
         return projectDao.storeDataSet(dataSet);
     }
+
+    public void delete(String projectSlug) {
+        projectDao.deleteDataSet(projectSlug);
+    }
 }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/management/ProjectModelRepository.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/management/ProjectModelRepository.java
@@ -12,6 +12,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
@@ -37,9 +38,10 @@ public class ProjectModelRepository {
         if (projectDao.projectExists(project.getSlug())) {
             throw new ProjectAlreadyExistsException(project.getSlug());
         }
+
         ProjectDataSet dataSet = projectMapper.map(project.getSlug(), project);
         projectDao.storeDataSet(dataSet);
-        return find(project.getSlug());
+        return find(project.getSlug()).orElseThrow();
     }
 
     /**
@@ -49,9 +51,12 @@ public class ProjectModelRepository {
      * @return the project with the given slug
      */
     @Transactional(Transactional.TxType.REQUIRED)
-    public ProjectModel find(String slug) {
-        ProjectDataSet dataSet = projectDao.loadDataSet(slug);
-        return projectMapper.map(dataSet);
+    public Optional<ProjectModel> find(String slug) {
+        var dataSet = projectDao.loadDataSet(slug);
+        if (dataSet.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(projectMapper.map(dataSet.get()));
     }
 
     @Transactional(Transactional.TxType.REQUIRED)

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/ConceptModelRepository.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/ConceptModelRepository.java
@@ -99,7 +99,7 @@ public class ConceptModelRepository {
         applySymmetricRelationChanges(model, existing);
 
         conceptDao.storeDataSet(conceptMapper.map(model));
-        eventService.send(ConceptEvent.updated(model));
+        eventService.send(ConceptEvent.updated(model, existing));
     }
 
     /**
@@ -185,7 +185,7 @@ public class ConceptModelRepository {
             );
 
             conceptDao.storeDataSet(conceptDataSet);
-            eventService.send(ConceptEvent.updated(conceptMapper.map(conceptDataSet)));
+            eventService.send(ConceptEvent.updated(conceptMapper.map(conceptDataSet), existing));
         };
 
         // For each broader, create a narrower relationship to this

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/ConceptModelRepository.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/ConceptModelRepository.java
@@ -196,4 +196,11 @@ public class ConceptModelRepository {
                             -> createRelationshipToModel.accept(relatedUuid, type.inverse()));
         }
     }
+
+    public void delete(UUID uuid) {
+        ConceptModel concept = find(uuid);
+        conceptDao.deleteDataSet(uuid);
+
+        eventService.send(ConceptEvent.deleted(concept));
+    }
 }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/ConceptSchemeModelRepository.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/ConceptSchemeModelRepository.java
@@ -74,4 +74,8 @@ public class ConceptSchemeModelRepository {
 
         return conceptSchemeDao.storeDataSet(dataset);
     }
+
+    public void delete(UUID uuid) {
+        conceptSchemeDao.deleteDataSet(uuid);
+    }
 }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptDao.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptDao.java
@@ -135,4 +135,10 @@ public class ConceptDao {
         jdbcTemplate.update("CALL update_concept_semantic_relations(?, ?, ?)", relationArgs, relationTypes);
     }
 
+    public void deleteDataSet(UUID uuid) {
+        Object[] recordArgs = {uuid};
+        int[] recordTypes = {Types.OTHER};
+
+        jdbcTemplate.update("CALL delete_concept(?)", recordArgs, recordTypes);
+    }
 }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptSchemeDao.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptSchemeDao.java
@@ -6,11 +6,9 @@ import com.digirati.taxman.rest.server.taxonomy.storage.record.ConceptSchemeReco
 import com.digirati.taxman.rest.server.taxonomy.storage.record.mapper.ConceptReferenceMapper;
 import com.digirati.taxman.rest.server.taxonomy.storage.record.mapper.ConceptSchemeRecordMapper;
 import org.json.JSONArray;
-import org.json.JSONObject;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.sql.DataSource;
-import java.sql.Array;
 import java.sql.Types;
 import java.util.UUID;
 
@@ -74,5 +72,12 @@ public class ConceptSchemeDao {
 
         changed |= jdbcTemplate.update("CALL update_concept_scheme_top_concepts(?, ?)", conceptArgs, conceptTypes) > 0;
         return changed;
+    }
+
+    public void deleteDataSet(UUID uuid) {
+        Object[] recordArgs = {uuid};
+        int[] recordTypes = {Types.OTHER};
+
+        jdbcTemplate.update("CALL delete_concept_scheme(?)", recordArgs, recordTypes);
     }
 }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/JdbcTemplateEx.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/JdbcTemplateEx.java
@@ -1,0 +1,87 @@
+package com.digirati.taxman.rest.server.taxonomy.storage;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.RowMapperResultSetExtractor;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.util.CollectionUtils;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * An extension of JdbcTemplate that provides a queryForOptional, as a variant
+ * of queryForObject that doesn't throw if the queried object is not found.
+ */
+public class JdbcTemplateEx extends JdbcTemplate {
+
+    JdbcTemplateEx(DataSource dataSource) {
+        super(dataSource);
+    }
+
+    /**
+     * Return an optional with either single result object from
+     * the given Collection, or Optional.empty() if collection
+     * is empty.
+     * <p>Throws an exception if more than 1 element found.
+     *
+     * @param results the result Collection (can be {@code null}
+     *                and is also expected to contain {@code null} elements)
+     * @return the single result object
+     * @throws IncorrectResultSizeDataAccessException if more than one
+     *                                                element has been found in the given Collection
+     */
+    private static <T> Optional<T> singleOptionalResult(@Nullable Collection<T> results) throws IncorrectResultSizeDataAccessException {
+        // This is identical to the nullableSingleResult implementation but returns
+        // Optional.empty() instead of throwing, if the results are empty
+        if (CollectionUtils.isEmpty(results)) {
+            return Optional.empty();
+        }
+        if (results.size() > 1) {
+            throw new IncorrectResultSizeDataAccessException(1, results.size());
+        }
+        return Optional.of(results.iterator().next());
+    }
+
+    @NonNull
+    <T> Optional<T> queryForOptional(String sql, Object[] args, int[] argTypes, RowMapper<T> rowMapper)
+            throws DataAccessException {
+
+        List<T> results = query(sql, args, argTypes, new RowMapperResultSetExtractor<>(rowMapper, 1));
+        return singleOptionalResult(results);
+    }
+
+    @NonNull
+    private <T> Optional<T> queryForOptional(String sql, @Nullable Object[] args, RowMapper<T> rowMapper) throws DataAccessException {
+        List<T> results = query(sql, args, new RowMapperResultSetExtractor<>(rowMapper, 1));
+        return singleOptionalResult(results);
+    }
+
+    @NonNull
+    public <T> Optional<T> queryForOptional(String sql, RowMapper<T> rowMapper, @Nullable Object... args) throws DataAccessException {
+        List<T> results = query(sql, args, new RowMapperResultSetExtractor<>(rowMapper, 1));
+        return singleOptionalResult(results);
+    }
+
+    @NonNull
+    public <T> Optional<T> queryForOptional(String sql, Object[] args, int[] argTypes, Class<T> requiredType)
+            throws DataAccessException {
+
+        return queryForOptional(sql, args, argTypes, getSingleColumnRowMapper(requiredType));
+    }
+
+    @NonNull
+    public <T> Optional<T> queryForOptional(String sql, Object[] args, Class<T> requiredType) throws DataAccessException {
+        return queryForOptional(sql, args, getSingleColumnRowMapper(requiredType));
+    }
+
+    @NonNull
+    public <T> Optional<T> queryForOptional(String sql, Class<T> requiredType, @Nullable Object... args) throws DataAccessException {
+        return queryForOptional(sql, args, getSingleColumnRowMapper(requiredType));
+    }
+}

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/ProjectDao.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/ProjectDao.java
@@ -5,12 +5,12 @@ import com.digirati.taxman.rest.server.taxonomy.storage.record.ProjectRecord;
 import com.digirati.taxman.rest.server.taxonomy.storage.record.mapper.ConceptSchemeRecordMapper;
 import com.digirati.taxman.rest.server.taxonomy.storage.record.mapper.ProjectRecordMapper;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.sql.DataSource;
 import java.sql.Array;
 import java.sql.Types;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -21,11 +21,11 @@ public class ProjectDao {
     private final ProjectRecordMapper projectRecordMapper = new ProjectRecordMapper();
     private final ConceptSchemeRecordMapper conceptSchemeRecordMapper = new ConceptSchemeRecordMapper();
     private final DataSource dataSource;
-    private final JdbcTemplate jdbcTemplate;
+    private final JdbcTemplateEx jdbcTemplate;
 
     public ProjectDao(DataSource dataSource) {
         this.dataSource = dataSource;
-        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        this.jdbcTemplate = new JdbcTemplateEx(dataSource);
     }
 
     /**
@@ -35,17 +35,21 @@ public class ProjectDao {
      * @return the project with the given slug
      * @throws EmptyResultDataAccessException when no project can be found with the given slug
      */
-    public ProjectDataSet loadDataSet(String slug) throws EmptyResultDataAccessException {
+    public Optional<ProjectDataSet> loadDataSet(String slug) throws EmptyResultDataAccessException {
         Object[] recordArgs = {slug};
         int[] recordTypes = {Types.VARCHAR};
 
-        ProjectRecord project = jdbcTemplate.queryForObject("SELECT * FROM get_project(?)",
+        Optional<ProjectRecord> project = jdbcTemplate.queryForOptional("SELECT * FROM get_project(?)",
                 recordArgs, recordTypes, projectRecordMapper);
+
+        if (project.isEmpty()) {
+            return Optional.empty();
+        }
 
         List<ConceptSchemeRecord> conceptSchemes = jdbcTemplate.query("SELECT * FROM get_project_concept_schemes(?)",
                 recordArgs, recordTypes, conceptSchemeRecordMapper);
 
-        return new ProjectDataSet(project, conceptSchemes);
+        return Optional.of(new ProjectDataSet(project.get(), conceptSchemes));
     }
 
     public List<ProjectRecord> findAll() {
@@ -59,12 +63,7 @@ public class ProjectDao {
      * @return true if a project with the slug exists; false otherwise
      */
     public boolean projectExists(String slug) {
-        try {
-            loadDataSet(slug);
-            return true;
-        } catch (EmptyResultDataAccessException e) {
-            return false;
-        }
+        return loadDataSet(slug).isPresent();
     }
 
     /**

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/ProjectDao.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/ProjectDao.java
@@ -4,7 +4,6 @@ import com.digirati.taxman.rest.server.taxonomy.storage.record.ConceptSchemeReco
 import com.digirati.taxman.rest.server.taxonomy.storage.record.ProjectRecord;
 import com.digirati.taxman.rest.server.taxonomy.storage.record.mapper.ConceptSchemeRecordMapper;
 import com.digirati.taxman.rest.server.taxonomy.storage.record.mapper.ProjectRecordMapper;
-import org.json.JSONObject;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -97,5 +96,12 @@ public class ProjectDao {
         int schemeChanges = jdbcTemplate.update("CALL update_project_concept_schemes(?, ?)", schemeArgs, schemeArgTypes);
 
         return (projectChanges | schemeChanges) > 0;
+    }
+
+    public void deleteDataSet(String slug) {
+        Object[] projectArgs = {slug};
+        int[] projectArgTypes = {Types.VARCHAR};
+
+        jdbcTemplate.update("CALL delete_project(?)", projectArgs, projectArgTypes);
     }
 }

--- a/taxonomy-manager-rest-server/src/main/resources/db/migration/V9__soft_delete.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/migration/V9__soft_delete.sql
@@ -1,0 +1,68 @@
+-- CONCEPT
+
+alter table skos_concept
+    add deleted boolean default false not null;
+
+create index skos_concept_note_deleted
+    on skos_concept (deleted)
+    where deleted = false;
+
+create or replace view skos_concept_ex as
+    select * from skos_concept where deleted = false;
+
+create index skos_concept_uuid_key_not_deleted
+    on skos_concept (uuid)
+    where deleted = false;
+
+create index skos_concept__uniq_source_not_deleted
+    on skos_concept (source)
+    where deleted = false;
+
+create index skos_concept_pkey_not_deleted
+    on skos_concept (id)
+    where deleted = false;
+
+
+-- PROJECT
+
+alter table project
+    add deleted boolean default false not null;
+
+create index project_note_deleted
+    on project (deleted)
+    where deleted = false;
+
+create or replace view project_ex as
+    select * from project where deleted = false;
+
+create index project_slug_key_not_deleted
+    on project (slug)
+    where deleted = false;
+
+create index project_pkey_not_deleted
+    on project (id)
+    where deleted = false;
+
+-- CONCEPT SCHEME
+
+alter table skos_concept_scheme
+    add deleted boolean default false not null;
+
+create index skos_concept_scheme_note_deleted
+    on skos_concept_scheme (deleted)
+    where deleted = false;
+
+create or replace view skos_concept_scheme_ex as
+    select * from skos_concept_scheme where deleted = false;
+
+create index skos_concept_scheme_uuid_key_not_deleted
+    on skos_concept_scheme (uuid)
+    where deleted = false;
+
+create index skos_concept_scheme__uniq_source_not_deleted
+    on skos_concept_scheme (source)
+    where deleted = false;
+
+create index skos_concept_scheme_pkey_not_deleted
+    on skos_concept_scheme (id)
+    where deleted = false;

--- a/taxonomy-manager-rest-server/src/main/resources/db/migration/V9__soft_delete.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/migration/V9__soft_delete.sql
@@ -3,10 +3,6 @@
 alter table skos_concept
     add deleted boolean default false not null;
 
-create index skos_concept_note_deleted
-    on skos_concept (deleted)
-    where deleted = false;
-
 create or replace view skos_concept_ex as
     select * from skos_concept where deleted = false;
 
@@ -28,10 +24,6 @@ create index skos_concept_pkey_not_deleted
 alter table project
     add deleted boolean default false not null;
 
-create index project_note_deleted
-    on project (deleted)
-    where deleted = false;
-
 create or replace view project_ex as
     select * from project where deleted = false;
 
@@ -47,10 +39,6 @@ create index project_pkey_not_deleted
 
 alter table skos_concept_scheme
     add deleted boolean default false not null;
-
-create index skos_concept_scheme_note_deleted
-    on skos_concept_scheme (deleted)
-    where deleted = false;
 
 create or replace view skos_concept_scheme_ex as
     select * from skos_concept_scheme where deleted = false;

--- a/taxonomy-manager-rest-server/src/main/resources/db/migration/V9__soft_delete.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/migration/V9__soft_delete.sql
@@ -3,6 +3,9 @@
 alter table skos_concept
     add deleted boolean default false not null;
 
+create unique index skos_concept__uniq_uuid_source_coalesce
+    on skos_concept(uuid, COALESCE(source,''));
+
 create or replace view skos_concept_ex as
     select * from skos_concept where deleted = false;
 
@@ -39,6 +42,9 @@ create index project_pkey_not_deleted
 
 alter table skos_concept_scheme
     add deleted boolean default false not null;
+
+create unique index skos_concept_scheme__uniq_uuid_source_coalesce
+    on skos_concept_scheme(uuid, COALESCE(source,''));
 
 create or replace view skos_concept_scheme_ex as
     select * from skos_concept_scheme where deleted = false;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__delete_project.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__delete_project.sql
@@ -4,4 +4,3 @@ create or replace procedure delete_project(_slug character varying)
 $$
 UPDATE project SET deleted = true WHERE project.slug = _slug;
 $$;
-

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__delete_project.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__delete_project.sql
@@ -2,5 +2,6 @@ drop procedure IF EXISTS delete_project(_slug character varying);
 create or replace procedure delete_project(_slug character varying)
     LANGUAGE SQL AS
 $$
-UPDATE project SET deleted = true WHERE project.slug = slug;
+UPDATE project SET deleted = true WHERE project.slug = _slug;
 $$;
+

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__delete_project.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__delete_project.sql
@@ -1,0 +1,6 @@
+drop procedure IF EXISTS delete_project(_slug character varying);
+create or replace procedure delete_project(_slug character varying)
+    LANGUAGE SQL AS
+$$
+UPDATE project SET deleted = true WHERE project.slug = slug;
+$$;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__get_all_projects.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__get_all_projects.sql
@@ -1,8 +1,8 @@
 DROP FUNCTION IF EXISTS get_all_projects();
-CREATE OR REPLACE FUNCTION get_all_projects() RETURNS SETOF project AS
+CREATE OR REPLACE FUNCTION get_all_projects() RETURNS SETOF project_ex AS
 $$
 BEGIN
     RETURN QUERY
-        SELECT project.* FROM project project;
+        SELECT project.* FROM project_ex project;
 END;
 $$ LANGUAGE plpgsql;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__get_project.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__get_project.sql
@@ -1,7 +1,13 @@
-CREATE OR REPLACE function get_project(_slug character varying) RETURNS SETOF project AS
+
+create function get_project(_slug character varying) returns SETOF project_ex
+    language plpgsql
+as
 $$
-BEGIN
-    RETURN QUERY
-        SELECT project.* FROM project WHERE project.slug = _slug;
-END
-$$ LANGUAGE plpgsql;
+begin
+    return QUERY
+        select project.* from project_ex project where project.slug = _slug;
+end
+$$;
+
+alter function get_project(varchar) owner to taxman;
+

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__get_project.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__get_project.sql
@@ -9,5 +9,3 @@ begin
 end
 $$;
 
-alter function get_project(varchar) owner to taxman;
-

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__get_project.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__get_project.sql
@@ -8,4 +8,3 @@ begin
         select project.* from project_ex project where project.slug = _slug;
 end
 $$;
-

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__get_project_concept_schemes.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/project/R__get_project_concept_schemes.sql
@@ -1,13 +1,13 @@
-CREATE OR REPLACE FUNCTION get_project_concept_schemes(_slug character varying)
+create or replace function get_project_concept_schemes(_slug character varying)
 RETURNS TABLE (uuid uuid, title rdf_plain_literal, source varchar)
-AS
+as
 $$
-BEGIN
-    RETURN QUERY
-        SELECT cs.uuid, cs.title, cs.source
-        FROM project_skos_concept_scheme pcs
-                INNER JOIN project p ON pcs.project_id = p.id
-                INNER JOIN skos_concept_scheme cs ON pcs.concept_scheme_id = cs.id
-        WHERE p.slug = _slug;
-END;
+begin
+    return QUERY
+        select cs.uuid, cs.title, cs.source
+        from project_skos_concept_scheme pcs
+                inner join project_ex p on pcs.project_id = p.id
+                inner join skos_concept_scheme_ex cs on pcs.concept_scheme_id = cs.id
+        where p.slug = _slug;
+end;
 $$ LANGUAGE plpgsql;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__delete_concept.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__delete_concept.sql
@@ -1,0 +1,11 @@
+DROP PROCEDURE IF exists delete_concept;
+DROP FUNCTION IF EXISTS delete_concept;
+
+CREATE OR REPLACE PROCEDURE delete_concept(_uuid uuid)
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    UPDATE skos_concept concept SET deleted = true WHERE concept.uuid = uuid;
+END;
+$$;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__delete_concept.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__delete_concept.sql
@@ -6,6 +6,6 @@ CREATE OR REPLACE PROCEDURE delete_concept(_uuid uuid)
 AS
 $$
 BEGIN
-    UPDATE skos_concept concept SET deleted = true WHERE concept.uuid = uuid;
+    UPDATE skos_concept concept SET deleted = true WHERE concept.uuid = _uuid;
 END;
 $$;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__get_all_concepts.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__get_all_concepts.sql
@@ -1,8 +1,8 @@
 DROP FUNCTION IF EXISTS get_all_concepts;
-CREATE OR REPLACE FUNCTION get_all_concepts() RETURNS SETOF skos_concept AS
+CREATE OR REPLACE FUNCTION get_all_concepts() RETURNS SETOF skos_concept_Ex AS
 $$
 BEGIN
     RETURN QUERY
-        SELECT concept.* FROM skos_concept concept;
+        SELECT concept.* FROM skos_concept_ex concept;
 END;
 $$ LANGUAGE plpgsql;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__get_concept.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__get_concept.sql
@@ -1,8 +1,8 @@
 DROP FUNCTION IF EXISTS get_concept;
-CREATE OR REPLACE FUNCTION get_concept(uniqid UUID) RETURNS SETOF skos_concept AS
+CREATE OR REPLACE FUNCTION get_concept(uniqid UUID) RETURNS SETOF skos_concept_ex AS
 $$
 BEGIN
     RETURN QUERY
-        SELECT concept.* FROM skos_concept concept WHERE concept.uuid = uniqid;
+        SELECT concept.* FROM skos_concept_ex concept WHERE concept.uuid = uniqid;
 END;
 $$ LANGUAGE plpgsql;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__get_concepts_by_partial_label.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__get_concepts_by_partial_label.sql
@@ -1,10 +1,10 @@
 DROP FUNCTION IF EXISTS get_concepts_by_partial_label;
-CREATE OR REPLACE FUNCTION get_concepts_by_partial_label(_label text, _language text) RETURNS SETOF skos_concept AS
+CREATE OR REPLACE FUNCTION get_concepts_by_partial_label(_label text, _language text) RETURNS SETOF skos_concept_ex AS
 $$
 BEGIN
     RETURN QUERY
         SELECT concept.*
-        FROM skos_concept concept
+        FROM skos_concept_ex concept
         WHERE contains_label_prefix(concept.preferred_label, _label, _language)
         OR contains_label_prefix(concept.alt_label, _label, _language)
         OR contains_label_prefix(concept.hidden_label, _label, _language);

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__get_concepts_by_uuids.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__get_concepts_by_uuids.sql
@@ -1,10 +1,10 @@
 DROP FUNCTION IF EXISTS get_concepts_by_uuids;
-CREATE OR REPLACE FUNCTION get_concepts_by_uuids(_uuids UUID[]) RETURNS SETOF skos_concept AS
+CREATE OR REPLACE FUNCTION get_concepts_by_uuids(_uuids UUID[]) RETURNS SETOF skos_concept_ex AS
 $$
 BEGIN
     RETURN QUERY
         SELECT concept.*
-        FROM skos_concept concept
+        FROM skos_concept_ex concept
         WHERE concept.uuid = ANY(_uuids);
 END;
 $$ LANGUAGE plpgsql;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__create_or_update_concept_scheme.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__create_or_update_concept_scheme.sql
@@ -1,43 +1,21 @@
-CREATE OR REPLACE PROCEDURE create_or_update_concept_scheme(_uuid uuid,
-                                                            _source varchar,
-                                                            _title rdf_plain_literal)
+CREATE OR REPLACE FUNCTION create_or_update_concept_scheme(_uuid uuid,
+                                                           _source varchar,
+                                                           _title rdf_plain_literal)
+    RETURNS SETOF skos_concept_scheme
     LANGUAGE plpgsql
 AS
 $$
 BEGIN
-    LOOP
-        -- First attempt to update an existing scheme by its UUID.
-        UPDATE skos_concept_scheme
-        SET title = _title
-        WHERE uuid = _uuid OR source = _source;
 
-        -- If a record was updated, we're done here.
-        IF found THEN
-            RETURN;
-        END IF;
+    RETURN QUERY
+        INSERT INTO skos_concept_scheme(uuid,source,title)
+        VALUES (_uuid, _source, _title)
+        ON CONFLICT (uuid, COALESCE(source,'')) DO UPDATE SET title = _title
+        RETURNING *;
+    EXCEPTION
+        WHEN unique_violation
+        THEN RAISE unique_violation USING MESSAGE =
+            'Concept Scheme violates the unique composite key of (uuid, source)';
 
-        -- If not, we try to create a record based on the source or UUID.
-        -- We do it in a loop so we don't race against others calling create_concept_scheme()
-        BEGIN
-            -- Attempt to create a concept scheme based on the source first.
-            INSERT INTO skos_concept_scheme (uuid, source, title)
-            VALUES (_uuid, _source, _title)
-            ON CONFLICT (source) DO UPDATE
-                SET title  = _title;
-            RETURN;
-        EXCEPTION
-            WHEN unique_violation THEN
-                BEGIN
-                    INSERT INTO skos_concept_scheme (uuid, source, title)
-                    VALUES (_uuid, _source, _title)
-                    ON CONFLICT (uuid) DO UPDATE
-                        SET title  = _title;
-                    RETURN;
-                EXCEPTION
-                    WHEN unique_violation THEN
-                    -- Do nothing, and loop to try the UPDATE again.
-                END;
-        END;
-    END LOOP;
 END;
 $$;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__delete_concept_scheme.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__delete_concept_scheme.sql
@@ -1,0 +1,6 @@
+DROP PROCEDURE IF EXISTS delete_concept_scheme;
+CREATE OR REPLACE PROCEDURE delete_concept_scheme(_uuid uuid)
+    LANGUAGE SQL AS
+$$
+    UPDATE skos_concept_scheme scheme SET deleted = true WHERE scheme.uuid = uuid;
+$$;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__delete_concept_scheme.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__delete_concept_scheme.sql
@@ -2,5 +2,5 @@ DROP PROCEDURE IF EXISTS delete_concept_scheme;
 CREATE OR REPLACE PROCEDURE delete_concept_scheme(_uuid uuid)
     LANGUAGE SQL AS
 $$
-    UPDATE skos_concept_scheme scheme SET deleted = true WHERE scheme.uuid = uuid;
+    UPDATE skos_concept_scheme scheme SET deleted = true WHERE scheme.uuid = _uuid;
 $$;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__get_concept_scheme.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__get_concept_scheme.sql
@@ -1,7 +1,7 @@
-CREATE OR REPLACE FUNCTION get_concept_scheme(uniqid UUID) RETURNS SETOF skos_concept_scheme AS
+CREATE OR REPLACE FUNCTION get_concept_scheme(uniqid UUID) RETURNS SETOF skos_concept_scheme_ex AS
 $$
 BEGIN
     RETURN QUERY
-        SELECT scheme.* FROM skos_concept_scheme scheme WHERE scheme.uuid = uniqid;
+        SELECT scheme.* FROM skos_concept_scheme_ex scheme WHERE scheme.uuid = uniqid;
 END;
 $$ LANGUAGE plpgsql;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__get_concept_scheme_top_concepts.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_scheme/R__get_concept_scheme_top_concepts.sql
@@ -12,8 +12,8 @@ BEGIN
     RETURN QUERY
         SELECT c.uuid, c.source, c.preferred_label
         FROM skos_concept_scheme_concept sc_entry
-                 INNER JOIN skos_concept_scheme cs ON cs.id = sc_entry.concept_scheme_id
-                 INNER JOIN skos_concept c ON c.id = sc_entry.concept_id
+                 INNER JOIN skos_concept_scheme_ex cs ON cs.id = sc_entry.concept_scheme_id
+                 INNER JOIN skos_concept_ex c ON c.id = sc_entry.concept_id
         WHERE cs.uuid = uniqid;
 END;
 $$ LANGUAGE plpgsql;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_semantic_relation/R__get_concept_semantic_relations.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_semantic_relation/R__get_concept_semantic_relations.sql
@@ -19,9 +19,9 @@ BEGIN
                relation.relation,
                relation.transitive
         FROM skos_concept_semantic_relation relation
-            INNER JOIN skos_concept sc
+            INNER JOIN skos_concept_ex sc
                 ON relation.source_id = sc.id
-            INNER JOIN skos_concept tc
+            INNER JOIN skos_concept_ex tc
                 ON relation.target_id = tc.id
         WHERE sc.uuid = _source_uuid;
 END;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_semantic_relation/R__get_concept_semantic_relations_recursive.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_semantic_relation/R__get_concept_semantic_relations_recursive.sql
@@ -1,6 +1,6 @@
 DROP FUNCTION IF EXISTS get_concept_semantic_relations_recursive;
 CREATE OR REPLACE FUNCTION get_concept_semantic_relations_recursive(_uuid uuid, _type skos_semantic_relation_type, _depth int)
-RETURNS SETOF skos_concept
+RETURNS SETOF skos_concept_ex
 AS
 $$
 BEGIN
@@ -16,7 +16,7 @@ BEGIN
                                       ARRAY [sr.source_id] AS visited_ids,
                                       FALSE                AS is_cycle
                                FROM skos_concept_semantic_relation sr
-                                        INNER JOIN skos_concept sc
+                                        INNER JOIN skos_concept_ex sc
                                                    ON sc.id = sr.source_id
                                WHERE sr.relation = _type
                                  AND sc.uuid = _uuid
@@ -36,9 +36,9 @@ BEGIN
                                  AND rsr.depth <= _depth)
         SELECT sct.*
         FROM relationships r
-                 inner join skos_concept scs
+                 inner join skos_concept_ex scs
                             ON scs.id = r.source_id
-                 inner join skos_concept sct
+                 inner join skos_concept_ex sct
                             ON sct.id = r.target_id;
 END;
 $$ LANGUAGE plpgsql;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_semantic_relation/R__update_concept_semantic_relations.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_semantic_relation/R__update_concept_semantic_relations.sql
@@ -5,10 +5,10 @@ create procedure update_concept_semantic_relations(_uuid uuid, _source character
 as
 $$
 -- If there are any relations that we don't have database records for yet, create them.
-INSERT INTO skos_concept (uuid, source)
+INSERT INTO skos_concept_ex (uuid, source)
 SELECT (data ->> 'target_id')::uuid, (data ->> 'target_source')::varchar
 FROM jsonb_array_elements(_relations) data
-         LEFT JOIN skos_concept sc ON sc.uuid = (data ->> 'target_id')::uuid
+         LEFT JOIN skos_concept_ex sc ON sc.uuid = (data ->> 'target_id')::uuid
     OR sc.source = (data ->> 'target_source')
 WHERE sc.uuid IS NULL
 ON CONFLICT DO NOTHING;
@@ -19,7 +19,7 @@ FROM skos_concept_semantic_relation scsr
     USING (
         SELECT r1.source_id, r1.target_id, r1.relation, r1.transitive
         FROM (SELECT c.id, c.uuid, c.source
-              FROM skos_concept c
+              FROM skos_concept_ex c
               WHERE c.uuid = _uuid
                  OR c.source = _source
              ) src
@@ -30,7 +30,7 @@ FROM skos_concept_semantic_relation scsr
                    (data ->> 'relation')::skos_semantic_relation_type relation,
                    (data ->> 'transitive')::boolean                   transitive
             FROM jsonb_array_elements(_relations) data
-                     LEFT JOIN skos_concept tc
+                     LEFT JOIN skos_concept_ex tc
                                ON tc.uuid = (data ->> 'target_id')::uuid
                                    OR tc.source = (data ->> 'target_source')
             WHERE tc.id IS NOT NULL
@@ -50,9 +50,9 @@ SELECT (data ->> 'relation')::skos_semantic_relation_type,
        sc.id,
        tc.id
 FROM jsonb_array_elements(_relations) data
-         LEFT JOIN skos_concept sc
+         LEFT JOIN skos_concept_ex sc
                    ON sc.uuid = _uuid OR sc.source = _source
-         LEFT JOIN skos_concept tc
+         LEFT JOIN skos_concept_ex tc
                    ON tc.uuid = (data ->> 'target_id')::uuid
                        OR tc.source = (data ->> 'target_source')
 ON CONFLICT DO NOTHING;

--- a/taxonomy-manager-rest-server/src/test/java/com/digirati/taxman/rest/server/ServerConceptResourceTest.java
+++ b/taxonomy-manager-rest-server/src/test/java/com/digirati/taxman/rest/server/ServerConceptResourceTest.java
@@ -5,7 +5,6 @@ import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
-import javax.transaction.Transactional;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
@@ -18,7 +17,6 @@ import static org.hamcrest.core.IsEqual.equalTo;
 public class ServerConceptResourceTest {
 
     @Test
-    @Transactional
     public void createConcept_JsonLd() {
         // @formatter:off
         givenJsonLdRequest(getClass(), "concept--create.json", Collections.emptyMap())
@@ -30,7 +28,6 @@ public class ServerConceptResourceTest {
     }
 
     @Test
-    @Transactional
     public void createConcept_JsonLdFailsValidationNoPrefLabel() {
         // @formatter:off
         givenJsonLdRequest(getClass(), "concept--create-no-pref-label.json", Collections.emptyMap())
@@ -42,7 +39,6 @@ public class ServerConceptResourceTest {
     }
 
     @Test
-    @Transactional
     public void createUpdate_RetainsDctermsSource() {
         // @formatter:off
         String conceptLocation =
@@ -73,57 +69,33 @@ public class ServerConceptResourceTest {
     }
 
     @Test
-    @Transactional
-    public void deleteConcept_ReturnsNoContent() {
-        // @formatter:off
-
-        String conceptLocation =
-                givenJsonLdRequest(getClass(), "concept--create-with-uri.json")
-                        .when()
-                        .post("/v0.1/concept")
-                        .then()
-                        .extract()
-                        .header("Location");
-
-        given()
-                .when()
-                .delete(URI.create(conceptLocation))
-                .then()
-                .statusCode(HttpStatus.SC_NO_CONTENT);
-
-        // @formatter:on
-    }
-
-    @Test
-    @Transactional
     public void getConcept_whenDeleted_notReturnsConcept() {
-        // @formatter:off
-
         String conceptLocation =
-                givenJsonLdRequest(getClass(), "concept--create-with-uri.json")
+                givenJsonLdRequest(getClass(), "concept--delete-with-uri.json")
                         .when()
-                        .post("/v0.1/concept")
+                            .post("/v0.1/concept")
                         .then()
-                        .extract()
-                        .header("Location");
+                            .extract()
+                            .header("Location");
 
         given()
                 .when()
-                .delete(URI.create(conceptLocation))
+                    .delete(URI.create(conceptLocation))
                 .then()
-                .statusCode(HttpStatus.SC_NO_CONTENT);
+                    .statusCode(HttpStatus.SC_NO_CONTENT);
 
         given()
                 .contentType("application/ld+json")
                 .accept("application/ld+json")
                 .when()
-                .get(URI.create(conceptLocation))
+                    .get(URI.create(conceptLocation))
                 .then()
-                .statusCode(Matchers.not(HttpStatus.SC_OK));
+                    .statusCode(Matchers.not(HttpStatus.SC_OK));
 
         // TODO: When proper responses are implemented, check for 410 gone or such
 
         // @formatter:on
     }
+
 
 }

--- a/taxonomy-manager-rest-server/src/test/java/com/digirati/taxman/rest/server/ServerConceptResourceTest.java
+++ b/taxonomy-manager-rest-server/src/test/java/com/digirati/taxman/rest/server/ServerConceptResourceTest.java
@@ -1,8 +1,11 @@
 package com.digirati.taxman.rest.server;
 
 import io.quarkus.test.junit.QuarkusTest;
+import org.apache.http.HttpStatus;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import javax.transaction.Transactional;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
@@ -15,6 +18,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 public class ServerConceptResourceTest {
 
     @Test
+    @Transactional
     public void createConcept_JsonLd() {
         // @formatter:off
         givenJsonLdRequest(getClass(), "concept--create.json", Collections.emptyMap())
@@ -26,6 +30,7 @@ public class ServerConceptResourceTest {
     }
 
     @Test
+    @Transactional
     public void createConcept_JsonLdFailsValidationNoPrefLabel() {
         // @formatter:off
         givenJsonLdRequest(getClass(), "concept--create-no-pref-label.json", Collections.emptyMap())
@@ -37,6 +42,7 @@ public class ServerConceptResourceTest {
     }
 
     @Test
+    @Transactional
     public void createUpdate_RetainsDctermsSource() {
         // @formatter:off
         String conceptLocation =
@@ -62,6 +68,60 @@ public class ServerConceptResourceTest {
                     .get(URI.create(conceptLocation))
                 .then()
                     .body("'dcterms:source'.'@id'", equalTo("https://example.org/my-id-001"));
+
+        // @formatter:on
+    }
+
+    @Test
+    @Transactional
+    public void deleteConcept_ReturnsNoContent() {
+        // @formatter:off
+
+        String conceptLocation =
+                givenJsonLdRequest(getClass(), "concept--create-with-uri.json")
+                        .when()
+                        .post("/v0.1/concept")
+                        .then()
+                        .extract()
+                        .header("Location");
+
+        given()
+                .when()
+                .delete(URI.create(conceptLocation))
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        // @formatter:on
+    }
+
+    @Test
+    @Transactional
+    public void getConcept_whenDeleted_notReturnsConcept() {
+        // @formatter:off
+
+        String conceptLocation =
+                givenJsonLdRequest(getClass(), "concept--create-with-uri.json")
+                        .when()
+                        .post("/v0.1/concept")
+                        .then()
+                        .extract()
+                        .header("Location");
+
+        given()
+                .when()
+                .delete(URI.create(conceptLocation))
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        given()
+                .contentType("application/ld+json")
+                .accept("application/ld+json")
+                .when()
+                .get(URI.create(conceptLocation))
+                .then()
+                .statusCode(Matchers.not(HttpStatus.SC_OK));
+
+        // TODO: When proper responses are implemented, check for 410 gone or such
 
         // @formatter:on
     }

--- a/taxonomy-manager-rest-server/src/test/java/com/digirati/taxman/rest/server/ServerConceptSchemeResourceTest.java
+++ b/taxonomy-manager-rest-server/src/test/java/com/digirati/taxman/rest/server/ServerConceptSchemeResourceTest.java
@@ -2,88 +2,39 @@ package com.digirati.taxman.rest.server;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.apache.http.HttpStatus;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
+import javax.transaction.TransactionManager;
 import javax.transaction.Transactional;
-
+import javax.transaction.UserTransaction;
 import java.net.URI;
 import java.util.Collections;
-import java.util.Map;
-import java.util.Random;
-import java.util.UUID;
 
 import static com.digirati.taxman.rest.server.testing.util.RestAssuredUtils.givenJsonLdRequest;
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 @QuarkusTest
 public class ServerConceptSchemeResourceTest {
 
     @Test
-    @Transactional
-    public void conceptScheme_Lifecycle() {
-        // 1. Create new scheme
-        String newSchemeLocation =
-                givenJsonLdRequest(getClass(), "concept-scheme--create-without-source.json", Collections.emptyMap())
-                        .when()
-                        .post("/v0.1/concept-scheme")
-                        .then()
-                        .statusCode(201)
-                        .extract()
-                        .header("location");
-
-        URI newSchemeUri = URI.create(newSchemeLocation);
-        String[] pathSegments = newSchemeUri.getPath().split("/");
-        String uuidStr = pathSegments[pathSegments.length - 1];
-        //UUID uuid = UUID.fromString();
-
-        // 2. Update it passing @id
-        givenJsonLdRequest(getClass(), "concept-scheme--update-title-without-source.json", Map.of("@id", newSchemeLocation))
-                .when()
-                .put("/v0.1/concept-scheme/" + uuidStr)
-                .then()
-                .statusCode(204);
-
-        // 3. Get and verify
-        given()
-                .when()
-                .get("/v0.1/concept-scheme/" + uuidStr)
-                .then()
-                .statusCode(200)
-                .body("'dcterms':'title'.'@language'", hasItems("en", "es"));
-
-        // 4. Delete
-        given()
-                .when()
-                .delete("/v0.1/concept-scheme/" + uuidStr)
-                .then()
-                .statusCode(204);
-    }
-
-    @Test
-    @Transactional
-    public void createConceptScheme_WithTopConcept() {
+    public void createConceptScheme_WithTopConcept() throws Exception {
         // @formatter:off
         givenJsonLdRequest(getClass(), "concept-scheme--create-with-top-concept.json", Collections.emptyMap())
                 .when()
-                    .post("/v0.1/concept-scheme")
+                .post("/v0.1/concept-scheme")
                 .then()
-                    .statusCode(201)
-                    .body("'dcterms:title'.'@value'", equalTo("Test"))
-                    .body("'skos:hasTopConcept'.'dcterms:source'.'@id'", equalTo("urn:top-concept"));
+                .statusCode(201)
+                .body("'dcterms:title'.'@value'", equalTo("Test"))
+                .body("'skos:hasTopConcept'.'dcterms:source'.'@id'", equalTo("urn:top-concept"));
         // @formatter:on
     }
 
     @Test
-    @Transactional
-    public void deleteConceptScheme_ReturnsNoContent() {
-        // @formatter:off
-
+    public void deleteConceptScheme_ReturnsNoContent() throws Exception {
         String conceptSchemeLocation =
-                givenJsonLdRequest(getClass(), "concept-scheme--create-with-top-concept.json", Collections.emptyMap())
+                givenJsonLdRequest(getClass(), "concept-scheme--delete.json", Collections.emptyMap())
                         .when()
                         .post("/v0.1/concept-scheme")
                         .then()
@@ -99,35 +50,4 @@ public class ServerConceptSchemeResourceTest {
         // @formatter:on
     }
 
-    @Test
-    @Transactional
-    public void getConcept_whenDeleted_notReturnsConcept() {
-        // @formatter:off
-
-        String conceptSchemeLocation =
-                givenJsonLdRequest(getClass(), "concept-scheme--create-with-top-concept.json", Collections.emptyMap())
-                        .when()
-                        .post("/v0.1/concept-scheme")
-                        .then()
-                        .extract()
-                        .header("Location");
-
-        given()
-                .when()
-                .delete(URI.create(conceptSchemeLocation))
-                .then()
-                .statusCode(HttpStatus.SC_NO_CONTENT);
-
-        given()
-                .contentType("application/ld+json")
-                .accept("application/ld+json")
-                .when()
-                .get(URI.create(conceptSchemeLocation))
-                .then()
-                .statusCode(Matchers.not(HttpStatus.SC_OK));
-
-        // TODO: When proper responses are implemented, check for 410 gone or such
-
-        // @formatter:on
-    }
 }

--- a/taxonomy-manager-rest-server/src/test/java/com/digirati/taxman/rest/server/ServerConceptSchemeResourceTest.java
+++ b/taxonomy-manager-rest-server/src/test/java/com/digirati/taxman/rest/server/ServerConceptSchemeResourceTest.java
@@ -1,20 +1,70 @@
 package com.digirati.taxman.rest.server;
 
 import io.quarkus.test.junit.QuarkusTest;
+import org.apache.http.HttpStatus;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import javax.transaction.Transactional;
 
+import java.net.URI;
 import java.util.Collections;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
 
 import static com.digirati.taxman.rest.server.testing.util.RestAssuredUtils.givenJsonLdRequest;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 @QuarkusTest
-@Transactional
 public class ServerConceptSchemeResourceTest {
+
     @Test
+    @Transactional
+    public void conceptScheme_Lifecycle() {
+        // 1. Create new scheme
+        String newSchemeLocation =
+                givenJsonLdRequest(getClass(), "concept-scheme--create-without-source.json", Collections.emptyMap())
+                        .when()
+                        .post("/v0.1/concept-scheme")
+                        .then()
+                        .statusCode(201)
+                        .extract()
+                        .header("location");
+
+        URI newSchemeUri = URI.create(newSchemeLocation);
+        String[] pathSegments = newSchemeUri.getPath().split("/");
+        String uuidStr = pathSegments[pathSegments.length - 1];
+        //UUID uuid = UUID.fromString();
+
+        // 2. Update it passing @id
+        givenJsonLdRequest(getClass(), "concept-scheme--update-title-without-source.json", Map.of("@id", newSchemeLocation))
+                .when()
+                .put("/v0.1/concept-scheme/" + uuidStr)
+                .then()
+                .statusCode(204);
+
+        // 3. Get and verify
+        given()
+                .when()
+                .get("/v0.1/concept-scheme/" + uuidStr)
+                .then()
+                .statusCode(200)
+                .body("'dcterms':'title'.'@language'", hasItems("en", "es"));
+
+        // 4. Delete
+        given()
+                .when()
+                .delete("/v0.1/concept-scheme/" + uuidStr)
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    @Transactional
     public void createConceptScheme_WithTopConcept() {
         // @formatter:off
         givenJsonLdRequest(getClass(), "concept-scheme--create-with-top-concept.json", Collections.emptyMap())
@@ -27,4 +77,57 @@ public class ServerConceptSchemeResourceTest {
         // @formatter:on
     }
 
+    @Test
+    @Transactional
+    public void deleteConceptScheme_ReturnsNoContent() {
+        // @formatter:off
+
+        String conceptSchemeLocation =
+                givenJsonLdRequest(getClass(), "concept-scheme--create-with-top-concept.json", Collections.emptyMap())
+                        .when()
+                        .post("/v0.1/concept-scheme")
+                        .then()
+                        .extract()
+                        .header("Location");
+
+        given()
+                .when()
+                .delete(URI.create(conceptSchemeLocation))
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        // @formatter:on
+    }
+
+    @Test
+    @Transactional
+    public void getConcept_whenDeleted_notReturnsConcept() {
+        // @formatter:off
+
+        String conceptSchemeLocation =
+                givenJsonLdRequest(getClass(), "concept-scheme--create-with-top-concept.json", Collections.emptyMap())
+                        .when()
+                        .post("/v0.1/concept-scheme")
+                        .then()
+                        .extract()
+                        .header("Location");
+
+        given()
+                .when()
+                .delete(URI.create(conceptSchemeLocation))
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        given()
+                .contentType("application/ld+json")
+                .accept("application/ld+json")
+                .when()
+                .get(URI.create(conceptSchemeLocation))
+                .then()
+                .statusCode(Matchers.not(HttpStatus.SC_OK));
+
+        // TODO: When proper responses are implemented, check for 410 gone or such
+
+        // @formatter:on
+    }
 }

--- a/taxonomy-manager-rest-server/src/test/java/com/digirati/taxman/rest/server/ServerProjectResourceTest.java
+++ b/taxonomy-manager-rest-server/src/test/java/com/digirati/taxman/rest/server/ServerProjectResourceTest.java
@@ -1,0 +1,92 @@
+package com.digirati.taxman.rest.server;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.http.HttpStatus;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import javax.transaction.Transactional;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Random;
+
+import static com.digirati.taxman.rest.server.testing.util.RestAssuredUtils.givenJsonLdRequest;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+@QuarkusTest
+@Transactional
+public class ServerProjectResourceTest {
+    private static final Random RANDOM = new Random();
+    @Test
+    public void createProject() {
+        // @formatter:off
+        givenJsonLdRequest(getClass(), "project--create.json", Map.of("dcterms:identifier", "test-project-" + RANDOM.nextInt()))
+                .when()
+                .post("/v0.1/project")
+                .then()
+                .statusCode(200)
+                .body("'dcterms:title'.'@value'", equalTo("Test Project"));
+        // @formatter:on
+    }
+
+    @Test
+    public void deleteProject_ReturnsNoContent() {
+        // @formatter:off
+
+        String identifier =
+                givenJsonLdRequest(getClass(), "project--create.json", Map.of("dcterms:identifier", "test-project-" + RANDOM.nextInt()))
+                        .when()
+                        .post("/v0.1/project")
+                        .then()
+                        .extract()
+                        .body()
+                        .jsonPath()
+                        .getString("'dcterms:identifier'");
+
+
+        given()
+                .when()
+                .delete("/v0.1/project/" + identifier)
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        // @formatter:on
+    }
+
+    @Test
+    public void getProject_whenDeleted_notReturnsConcept() {
+        // @formatter:off
+
+        String identifier =
+                givenJsonLdRequest(getClass(), "project--create.json", Map.of("dcterms:identifier", "test-project-" + RANDOM.nextInt()))
+                        .when()
+                        .post("/v0.1/project")
+                        .then()
+                        .extract()
+                        .body()
+                        .jsonPath()
+                        .getString("'dcterms:identifier'");
+
+
+        given()
+                .when()
+                .delete("/v0.1/project/" + identifier)
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+
+        given()
+                .contentType("application/ld+json")
+                .accept("application/ld+json")
+                .when()
+                .get("/v0.1/project/" + identifier)
+                .then()
+                .statusCode(Matchers.not(HttpStatus.SC_OK));
+
+        // TODO: When proper responses are implemented, check for 410 gone or such
+
+        // @formatter:on
+    }
+}

--- a/taxonomy-manager-rest-server/src/test/java/com/digirati/taxman/rest/server/ServerProjectResourceTest.java
+++ b/taxonomy-manager-rest-server/src/test/java/com/digirati/taxman/rest/server/ServerProjectResourceTest.java
@@ -6,8 +6,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import javax.transaction.Transactional;
-import java.net.URI;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
 
@@ -18,16 +16,17 @@ import static org.hamcrest.core.IsEqual.equalTo;
 @QuarkusTest
 @Transactional
 public class ServerProjectResourceTest {
+
     private static final Random RANDOM = new Random();
     @Test
     public void createProject() {
         // @formatter:off
         givenJsonLdRequest(getClass(), "project--create.json", Map.of("dcterms:identifier", "test-project-" + RANDOM.nextInt()))
                 .when()
-                .post("/v0.1/project")
+                    .post("/v0.1/project")
                 .then()
-                .statusCode(200)
-                .body("'dcterms:title'.'@value'", equalTo("Test Project"));
+                    .statusCode(200)
+                    .body("'dcterms:title'.'@value'", equalTo("Test Project"));
         // @formatter:on
     }
 
@@ -38,19 +37,19 @@ public class ServerProjectResourceTest {
         String identifier =
                 givenJsonLdRequest(getClass(), "project--create.json", Map.of("dcterms:identifier", "test-project-" + RANDOM.nextInt()))
                         .when()
-                        .post("/v0.1/project")
+                            .post("/v0.1/project")
                         .then()
-                        .extract()
-                        .body()
-                        .jsonPath()
-                        .getString("'dcterms:identifier'");
+                            .extract()
+                            .body()
+                            .jsonPath()
+                            .getString("'dcterms:identifier'");
 
 
         given()
                 .when()
-                .delete("/v0.1/project/" + identifier)
+                    .delete("/v0.1/project/" + identifier)
                 .then()
-                .statusCode(HttpStatus.SC_NO_CONTENT);
+                    .statusCode(HttpStatus.SC_NO_CONTENT);
 
         // @formatter:on
     }
@@ -62,28 +61,28 @@ public class ServerProjectResourceTest {
         String identifier =
                 givenJsonLdRequest(getClass(), "project--create.json", Map.of("dcterms:identifier", "test-project-" + RANDOM.nextInt()))
                         .when()
-                        .post("/v0.1/project")
+                            .post("/v0.1/project")
                         .then()
-                        .extract()
-                        .body()
-                        .jsonPath()
-                        .getString("'dcterms:identifier'");
+                            .extract()
+                            .body()
+                            .jsonPath()
+                            .getString("'dcterms:identifier'");
 
 
         given()
                 .when()
-                .delete("/v0.1/project/" + identifier)
+                    .delete("/v0.1/project/" + identifier)
                 .then()
-                .statusCode(HttpStatus.SC_NO_CONTENT);
+                    .statusCode(HttpStatus.SC_NO_CONTENT);
 
 
         given()
                 .contentType("application/ld+json")
                 .accept("application/ld+json")
                 .when()
-                .get("/v0.1/project/" + identifier)
+                    .get("/v0.1/project/" + identifier)
                 .then()
-                .statusCode(Matchers.not(HttpStatus.SC_OK));
+                    .statusCode(Matchers.not(HttpStatus.SC_OK));
 
         // TODO: When proper responses are implemented, check for 410 gone or such
 

--- a/taxonomy-manager-rest-server/src/test/resources/com/digirati/taxman/rest/server/concept--delete-with-uri.json
+++ b/taxonomy-manager-rest-server/src/test/resources/com/digirati/taxman/rest/server/concept--delete-with-uri.json
@@ -1,0 +1,12 @@
+{
+    "@context": {
+        "dcterms": "http://purl.org/dc/terms/",
+        "skos": "http://www.w3.org/2004/02/skos/core#"
+    },
+    "@id": "https://example.org/my-id-for-deletion-001",
+    "@type": "skos:Concept",
+    "skos:prefLabel": [{
+        "@language": "en",
+        "@value": "Test"
+    }]
+}

--- a/taxonomy-manager-rest-server/src/test/resources/com/digirati/taxman/rest/server/concept-scheme--create-without-source.json
+++ b/taxonomy-manager-rest-server/src/test/resources/com/digirati/taxman/rest/server/concept-scheme--create-without-source.json
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "dcterms": "http://purl.org/dc/terms/",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@type": "skos:ConceptScheme",
+  "dcterms:title": [
+    {
+      "@language": "en",
+      "@value": "Test-F1"
+    }
+  ]
+}

--- a/taxonomy-manager-rest-server/src/test/resources/com/digirati/taxman/rest/server/concept-scheme--delete.json
+++ b/taxonomy-manager-rest-server/src/test/resources/com/digirati/taxman/rest/server/concept-scheme--delete.json
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "dcterms": "http://purl.org/dc/terms/",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@type": "skos:ConceptScheme",
+  "dcterms:title": [{
+    "@language": "en",
+    "@value": "Test"
+  }],
+  "skos:hasTopConcept": [
+  ]
+}

--- a/taxonomy-manager-rest-server/src/test/resources/com/digirati/taxman/rest/server/concept-scheme--update-title-without-source.json
+++ b/taxonomy-manager-rest-server/src/test/resources/com/digirati/taxman/rest/server/concept-scheme--update-title-without-source.json
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "dcterms": "http://purl.org/dc/terms/"
+  },
+  "@type": "skos:ConceptScheme",
+  "dcterms:title": [
+    {
+      "@language": "en",
+      "@value": "Test-F1"
+    },
+    {
+      "@language": "es",
+      "@value": "Test-F1-es"
+    }
+  ]
+}

--- a/taxonomy-manager-rest-server/src/test/resources/com/digirati/taxman/rest/server/project--create.json
+++ b/taxonomy-manager-rest-server/src/test/resources/com/digirati/taxman/rest/server/project--create.json
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dcterms": "http://purl.org/dc/terms/",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@type": "rdfs:Dataset",
+  "dcterms:identifier": "test-project",
+  "dcterms:title": [
+    {
+      "@language": "en",
+      "@value": "Test Project"
+    }
+  ],
+  "dcterms:hasPart": []
+}

--- a/taxonomy-manager-rest/src/main/java/com/digirati/taxman/rest/taxonomy/ConceptResource.java
+++ b/taxonomy-manager-rest/src/main/java/com/digirati/taxman/rest/taxonomy/ConceptResource.java
@@ -2,20 +2,10 @@ package com.digirati.taxman.rest.taxonomy;
 
 import com.digirati.taxman.common.rdf.annotation.jsonld.JsonLdFrame;
 import com.digirati.taxman.common.taxonomy.ConceptModel;
-import com.digirati.taxman.common.taxonomy.ConceptRelationshipType;
 import com.digirati.taxman.rest.MediaTypes;
-import com.digirati.taxman.rest.Roles;
 
-import javax.annotation.security.RolesAllowed;
 import javax.validation.Valid;
-import javax.ws.rs.BeanParam;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 
 @Path("/v0.1/concept")
@@ -50,4 +40,8 @@ public interface ConceptResource {
     @Path("/{concept}")
     @Consumes({MediaTypes.APPLICATION_RDF_XML_VALUE, MediaTypes.APPLICATION_JSONLD_SKOS_VALUE})
     Response updateConcept(@BeanParam ConceptPath params, @Valid ConceptModel model);
+
+    @DELETE
+    @Path("/{concept}")
+    Response deleteConcept(@BeanParam ConceptPath params);
 }

--- a/taxonomy-manager-rest/src/main/java/com/digirati/taxman/rest/taxonomy/ConceptSchemeResource.java
+++ b/taxonomy-manager-rest/src/main/java/com/digirati/taxman/rest/taxonomy/ConceptSchemeResource.java
@@ -3,20 +3,10 @@ package com.digirati.taxman.rest.taxonomy;
 import com.digirati.taxman.common.rdf.annotation.jsonld.JsonLdFrame;
 import com.digirati.taxman.common.taxonomy.ConceptSchemeModel;
 import com.digirati.taxman.rest.MediaTypes;
-import com.digirati.taxman.rest.Roles;
 
-import javax.annotation.security.RolesAllowed;
 import javax.validation.Valid;
-import javax.ws.rs.BeanParam;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
-import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 
 @Path("/v0.1/concept-scheme")
 public interface ConceptSchemeResource {
@@ -37,4 +27,8 @@ public interface ConceptSchemeResource {
     @Path("/{scheme}")
     @Consumes({MediaTypes.APPLICATION_RDF_XML_VALUE, MediaTypes.APPLICATION_JSONLD_SKOS_VALUE})
     Response updateConceptScheme(@BeanParam ConceptSchemePath params, @Valid ConceptSchemeModel model);
+
+    @DELETE
+    @Path("/{scheme}")
+    Response deleteConceptScheme(@BeanParam ConceptSchemePath params);
 }

--- a/taxonomy-manager-rest/src/main/java/com/digirati/taxman/rest/taxonomy/ProjectResource.java
+++ b/taxonomy-manager-rest/src/main/java/com/digirati/taxman/rest/taxonomy/ProjectResource.java
@@ -3,17 +3,9 @@ package com.digirati.taxman.rest.taxonomy;
 import com.digirati.taxman.common.rdf.annotation.jsonld.JsonLdFrame;
 import com.digirati.taxman.common.taxonomy.ProjectModel;
 import com.digirati.taxman.rest.MediaTypes;
-import com.digirati.taxman.rest.Roles;
 
-import javax.annotation.security.RolesAllowed;
 import javax.validation.Valid;
-import javax.ws.rs.BeanParam;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 
 @Path("/v0.1/project")
@@ -40,4 +32,8 @@ public interface ProjectResource {
     @Path("/{project}")
     @Consumes({MediaTypes.APPLICATION_RDF_XML_VALUE, MediaTypes.APPLICATION_JSONLD_SKOS_VALUE})
     Response updateProject(@BeanParam ProjectPath projectPath, @Valid ProjectModel project);
+
+    @DELETE
+    @Path("/{project}")
+    Response deleteProject(@BeanParam ProjectPath projectPath);
 }

--- a/taxonomy-manager-rest/src/main/java/com/digirati/taxman/rest/taxonomy/ProjectResource.java
+++ b/taxonomy-manager-rest/src/main/java/com/digirati/taxman/rest/taxonomy/ProjectResource.java
@@ -5,7 +5,14 @@ import com.digirati.taxman.common.taxonomy.ProjectModel;
 import com.digirati.taxman.rest.MediaTypes;
 
 import javax.validation.Valid;
-import javax.ws.rs.*;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.core.Response;
 
 @Path("/v0.1/project")

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Version of the produced binaries. This file is intended to be checked-in.
 # It will be automatically bumped by release automation.
-version=0.1.2
+version=999-SNAPSHOT


### PR DESCRIPTION
## Goal
1. Allow making DELETE REST calls to Concept, Concept Scheme and Project resources
1. Soft delete the aforementioned resources

### Additional Goals
1. Ensure that deletion of Concepts affects the extraction

## Design
### API
Cookie-cutter endpoint dispatching request to the relevant repository class. Returns 204 No Content as per guidelines.

### Repository Layer
#### Projects and Concept Schemes
Direct pass-through to the DAO layer
#### Concepts
Call DAO layer, but also create and dispatch a `ConceptEvent`.

### DAO Layer
Execute the stored procedure that will perform operations necessary for deletion of the resource.

*Note:* using `jdbcTemplate.update` as procedures are simple and other ways to call seem unnecessarily convoluted. This way we have more consistent code with no obvious downsides due to that choice. 

### Data Layer
#### DDL Changes
1. Added `deleted boolean default false not null` column to `skos_concept`, `skos_concept_scheme` and `project` tables
1. Created an index based on the deletion status on each table
1. Created a `<table_name>_ex` (`ex`-isting) view for each table

#### Stored Procedures
1. Modified all procedures where data was read from any of the three modified tables, to use the `_ex` view instead
  1. This is a very simple and easy win, as it abstracts the deletion status from the codebase
1. Added `delete_<table_name>(unique_identifier)` procedures, which simply switch the `deleted` column value to `true`

## Event System
As of the current base branch version the Event System is not being used.

To ensure that the deletion of a Concept affects the Extraction without a need for a restart (which is a big hurdle in a PRD environment), I have modified and built upon the existing Event System infrastructure.

### ConceptEvent
1. Added new `DELETED` type
1. Added new `ConceptModel previous` field
  1. Rationale:
      1. `CREATED` event: no previous -> nothing to delete. New item -> things to index.
      1. `DELETED` event: previous -> delete from index. No new item -> nothing to add.
      1. `UPDATED` event: prvious -> delete from index. New item -> things to index.
      1. As can be seen, this setup allows very simple and not repetitive code to handle all three cases with just two methods.
1. Added appropriate constructor and aligned code to the changes

### ConceptEventListener
1. Subscribed the existing Listener to the events of type `ConceptEvent`.
1. Depending on the existence of previous and/or new item in the event, the old ones are unindexed and the new ones are indexed.

In the end, those changes also implement previously unsupported stories:
* When a new Concept is added to the Taxonomy, it can be immediately returned, if applicable, from Extraction endpoint
* When a Concept is modified (e.g. new Alt Label is added), the changes are reflected in the Extraction endpoint immediately.

As well as the desired "deletion" one.

## Limitations, Known Issues and Further Changes
### Frontend
* Project Deletion button in the UI does not make the DELETE call to the backend.
### Backend
* Project Deletion action does not affect the Extraction. This is due to the lack of Project Scoping. When implementing Project Scoping, changes must be made to also treat the deleted projects correctly.