### PR TITLE
Database project IDs, updated migrations

### DIFF
--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/PersistentProjectScopedModel.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/PersistentProjectScopedModel.java
@@ -1,9 +1,7 @@
 package com.digirati.taxman.common.rdf;
 
-import java.util.UUID;
-
 public interface PersistentProjectScopedModel extends PersistentModel {
-    UUID getProjectId();
+    String getProjectId();
 
-    void setProjectId(UUID uuid);
+    void setProjectId(String id);
 }

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/PersistentProjectScopedModel.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/PersistentProjectScopedModel.java
@@ -1,0 +1,9 @@
+package com.digirati.taxman.common.rdf;
+
+import java.util.UUID;
+
+public interface PersistentProjectScopedModel extends PersistentModel {
+    UUID getProjectId();
+
+    void setProjectId(UUID uuid);
+}

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/RdfModelCreationListener.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/RdfModelCreationListener.java
@@ -1,0 +1,10 @@
+package com.digirati.taxman.common.rdf;
+
+import com.google.common.collect.Multimap;
+import org.apache.jena.rdf.model.Resource;
+
+import java.util.Map;
+
+public interface RdfModelCreationListener {
+    void onCreation(RdfModel model, Resource resource, Multimap<String, String> additionalAttributes) throws RdfModelException;
+}

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/RdfModelFactory.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/RdfModelFactory.java
@@ -1,7 +1,9 @@
 package com.digirati.taxman.common.rdf;
 
 import com.digirati.taxman.common.rdf.identity.IdResolver;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ResIterator;
@@ -10,9 +12,8 @@ import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -20,6 +21,16 @@ import java.util.Map;
  * A factory that produces {@link RdfModel}s and {@link RdfModelBuilder}s.
  */
 public class RdfModelFactory {
+
+    private final List<RdfModelCreationListener> listeners;
+
+    public RdfModelFactory() {
+        this(Collections.emptyList());
+    }
+
+    public RdfModelFactory(List<RdfModelCreationListener> listeners) {
+        this.listeners = listeners;
+    }
 
     /**
      * Create a new {@link RdfModelBuilder} for models of the given {@code type}.
@@ -39,6 +50,10 @@ public class RdfModelFactory {
     }
 
     public <T extends RdfModel> T create(Class<T> type, Resource resource) throws RdfModelException {
+        return create(type, resource, HashMultimap.create());
+    }
+
+    public <T extends RdfModel> T create(Class<T> type, Resource resource, Multimap<String, String> additionalAttributes) throws RdfModelException {
         RdfModelMetadata<T> metadata = RdfModelMetadata.from(type);
 
         try {
@@ -49,22 +64,29 @@ public class RdfModelFactory {
             var uuid = IdResolver.resolve(uri, metadata.pattern);
             var setSource = !uuid.isPresent();
 
-
-
             StmtIterator stmts = resource.listProperties();
 
             if (setSource && !resource.hasProperty(DCTerms.source) && uri != null && stmts.hasNext()) {
                 resource.addProperty(DCTerms.source, resource);
             }
 
-            return metadata.constructor.newInstance(new RdfModelContext(this, resource));
+            T model = metadata.constructor.newInstance(new RdfModelContext(this, resource));
+            for (var listener : listeners) {
+                listener.onCreation(model, resource, additionalAttributes);
+            }
+
+            return model;
         } catch (ReflectiveOperationException e) {
             throw new RdfModelException("Unable to create RDF mapped model class", e);
         }
     }
 
     public <T extends RdfModel> T create(Class<T> type, Model model) throws RdfModelException {
-        return Iterables.getOnlyElement(createListFromModel(type, model));
+        return create(type, model, HashMultimap.create());
+    }
+
+    public <T extends RdfModel> T create(Class<T> type, Model model, Multimap<String, String> attributes) throws RdfModelException {
+        return Iterables.getOnlyElement(createListFromModel(type, model, attributes));
     }
 
     /**
@@ -78,6 +100,21 @@ public class RdfModelFactory {
      */
     public <T extends RdfModel> List<T> createListFromModel(Class<T> type, Model model)
             throws RdfModelException {
+        return createListFromModel(type, model, HashMultimap.create());
+    }
+
+    /**
+     * Read a list of of typed models from the given RDF graph.
+     *
+     * @param <T>   The type of the model to begin building.
+     * @param type  The class of the type of model to begin building.
+     * @param model The RDF graph to read data from.
+     * @param attributes
+     * @return a {@link List} of typed models found within the RDF graph.
+     * @throws RdfModelException if the given {@code type} has no valid {@link RdfModelMetadata}>
+     */
+    public <T extends RdfModel> List<T> createListFromModel(Class<T> type, Model model, Multimap<String, String> attributes)
+            throws RdfModelException {
 
         var resources = new ArrayList<T>();
 
@@ -87,7 +124,7 @@ public class RdfModelFactory {
         ResIterator resourceIterator = model.listResourcesWithProperty(RDF.type, metadata.type);
         while (resourceIterator.hasNext()) {
             Resource resource = resourceIterator.nextResource();
-            resources.add(create(type, resource));
+            resources.add(create(type, resource, attributes));
         }
 
 

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/io/RdfModelReader.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/io/RdfModelReader.java
@@ -56,7 +56,7 @@ public class RdfModelReader {
             throw new RdfModelException("RDF error produced on deserialization", ex);
         }
 
-        return modelFactory.createListFromModel(type, model);
+        return modelFactory.createListFromModel(type, model, attributes);
     }
 
     /**

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/io/RdfModelReader.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/rdf/io/RdfModelReader.java
@@ -4,7 +4,9 @@ import com.digirati.taxman.common.rdf.RdfModel;
 import com.digirati.taxman.common.rdf.RdfModelException;
 import com.digirati.taxman.common.rdf.RdfModelFactory;
 import com.digirati.taxman.common.rdf.RdfModelFormat;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.shared.JenaException;
@@ -33,6 +35,18 @@ public class RdfModelReader {
     public <T extends RdfModel> List<T> readAll(
             Class<T> type, RdfModelFormat format, InputStream modelStream)
             throws RdfModelException {
+        return readAll(type, format, modelStream, HashMultimap.create());
+    }
+
+    /**
+     * Read a list of {@link RdfModel} types from a stream of input containing RDF data in any of
+     * the {@link RdfModelFormat}s.
+     *
+     * @throws RdfModelException if an error occurred during reading of the RDF data.
+     */
+    public <T extends RdfModel> List<T> readAll(
+            Class<T> type, RdfModelFormat format, InputStream modelStream, Multimap<String, String> attributes)
+            throws RdfModelException {
 
         Model model;
         try {
@@ -48,16 +62,17 @@ public class RdfModelReader {
     /**
      * Read a single typed {@link RdfModel} from the RDF graph provided in the {@code modelStream}.
      *
+     * @param <T>         The type of the typed model.
      * @param type        The class of the typed model to read.
      * @param format      The format the graph in {@code modelStream} is encoded in.
      * @param modelStream The input stream containing the RDF graph.
-     * @param <T>         The type of the typed model.
+     * @param attributes
      * @return A typed {@link RdfModel} deserialized from the input graph.
      * @throws RdfModelException if the graph is ill-formed, or an error is produced by JENA.
      */
     public <T extends RdfModel> T read(
-            Class<T> type, RdfModelFormat format, InputStream modelStream)
+            Class<T> type, RdfModelFormat format, InputStream modelStream, Multimap<String, String> attributes)
             throws RdfModelException {
-        return Iterables.getOnlyElement(readAll(type, format, modelStream));
+        return Iterables.getOnlyElement(readAll(type, format, modelStream, attributes));
     }
 }

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/taxonomy/Concept.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/taxonomy/Concept.java
@@ -13,6 +13,8 @@ public interface Concept {
 
     UUID getUuid();
 
+    String getProjectId();
+
     String getSource();
 
     Multimap<String, String> getPreferredLabel();

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/taxonomy/ConceptModel.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/taxonomy/ConceptModel.java
@@ -1,6 +1,7 @@
 package com.digirati.taxman.common.taxonomy;
 
 import com.digirati.taxman.common.rdf.PersistentModel;
+import com.digirati.taxman.common.rdf.PersistentProjectScopedModel;
 import com.digirati.taxman.common.rdf.RdfModel;
 import com.digirati.taxman.common.rdf.RdfModelContext;
 import com.digirati.taxman.common.rdf.annotation.RdfConstructor;
@@ -19,10 +20,11 @@ import java.util.stream.Stream;
 
 @RdfType("http://www.w3.org/2004/02/skos/core#Concept")
 @RdfContext(value = {"skos=" + SKOS.uri, "dcterms=" + DCTerms.NS}, template = "/v0.1/concept/:id:")
-public final class ConceptModel implements RdfModel, PersistentModel, Concept {
+public final class ConceptModel implements Concept, RdfModel, PersistentProjectScopedModel {
 
     private final RdfModelContext context;
     private UUID uuid;
+    private UUID projectId;
 
     @RdfConstructor
     public ConceptModel(RdfModelContext context) {
@@ -119,5 +121,15 @@ public final class ConceptModel implements RdfModel, PersistentModel, Concept {
 
         return getResources(ConceptModel.class, skosProperty);
 
+    }
+
+    @Override
+    public UUID getProjectId() {
+        return projectId;
+    }
+
+    @Override
+    public void setProjectId(UUID uuid) {
+        this.projectId = projectId;
     }
 }

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/taxonomy/ConceptModel.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/taxonomy/ConceptModel.java
@@ -1,6 +1,5 @@
 package com.digirati.taxman.common.taxonomy;
 
-import com.digirati.taxman.common.rdf.PersistentModel;
 import com.digirati.taxman.common.rdf.PersistentProjectScopedModel;
 import com.digirati.taxman.common.rdf.RdfModel;
 import com.digirati.taxman.common.rdf.RdfModelContext;
@@ -8,13 +7,10 @@ import com.digirati.taxman.common.rdf.annotation.RdfConstructor;
 import com.digirati.taxman.common.rdf.annotation.RdfContext;
 import com.digirati.taxman.common.rdf.annotation.RdfType;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Streams;
 import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.SKOS;
 
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -24,7 +20,7 @@ public final class ConceptModel implements Concept, RdfModel, PersistentProjectS
 
     private final RdfModelContext context;
     private UUID uuid;
-    private UUID projectId;
+    private String projectId;
 
     @RdfConstructor
     public ConceptModel(RdfModelContext context) {
@@ -124,12 +120,12 @@ public final class ConceptModel implements Concept, RdfModel, PersistentProjectS
     }
 
     @Override
-    public UUID getProjectId() {
+    public String getProjectId() {
         return projectId;
     }
 
     @Override
-    public void setProjectId(UUID uuid) {
+    public void setProjectId(String id) {
         this.projectId = projectId;
     }
 }

--- a/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/taxonomy/ConceptModel.java
+++ b/taxonomy-manager-common/src/main/java/com/digirati/taxman/common/taxonomy/ConceptModel.java
@@ -126,6 +126,6 @@ public final class ConceptModel implements Concept, RdfModel, PersistentProjectS
 
     @Override
     public void setProjectId(String id) {
-        this.projectId = projectId;
+        this.projectId = id;
     }
 }

--- a/taxonomy-manager-engine/src/main/java/com/digirati/taxman/analysis/index/TermIndex.java
+++ b/taxonomy-manager-engine/src/main/java/com/digirati/taxman/analysis/index/TermIndex.java
@@ -4,32 +4,41 @@ import com.digirati.taxman.analysis.TermMatch;
 import com.digirati.taxman.analysis.WordTokenSearchEntry;
 import com.digirati.taxman.analysis.WordTokenSearchStrategy;
 import com.digirati.taxman.analysis.WordTokenizer;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Multiset;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A naive {@code O(N * M * 3)} string search algorithm that performs text normalization on stored terms
  * and input queries.
  */
-public class TermIndex<IdT>  {
+public class TermIndex<ScopeT, IdT>  {
 
     private final WordTokenizer tokenizer;
     private final WordTokenSearchStrategy<IdT> searchStrategy;
+    private final Multimap<ScopeT, IdT> scopedIds = MultimapBuilder.hashKeys().hashSetValues().build();
 
     public TermIndex(WordTokenizer tokenizer, WordTokenSearchStrategy<IdT> searchStrategy) {
         this.tokenizer = tokenizer;
         this.searchStrategy = searchStrategy;
     }
 
-    public void addAll(Map<IdT, String> terms) {
-        terms.forEach(this::add);
+    public void addAll(ScopeT scope, Map<IdT, String> terms) {
+        terms.forEach((id, term) -> add(scope, id, term));
+        scopedIds.putAll(scope, terms.keySet());
     }
 
-    public void add(IdT id, String text) {
+    public void add(ScopeT scope, IdT id, String text) {
         var tokens = tokenizer.tokenize(text);
         var entry = new WordTokenSearchEntry<>(id, tokens);
 
+        scopedIds.put(scope, id);
         searchStrategy.index(entry);
     }
 
@@ -38,6 +47,13 @@ public class TermIndex<IdT>  {
         var entry = new WordTokenSearchEntry<>(id, tokens);
 
         searchStrategy.unindex(entry);
+    }
+
+    public Set<TermMatch<IdT>> match(ScopeT scope, String input) {
+        return match(input)
+                .stream()
+                .filter(term -> scopedIds.containsEntry(scope, term.getId()))
+                .collect(Collectors.toSet());
     }
 
     public Set<TermMatch<IdT>> match(String input) {

--- a/taxonomy-manager-engine/src/test/java/com/digirati/taxman/analysis/index/TermIndexTest.java
+++ b/taxonomy-manager-engine/src/test/java/com/digirati/taxman/analysis/index/TermIndexTest.java
@@ -7,11 +7,14 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TermIndexTest {
-    protected TermIndex<String> create() {
+    private static final UUID DUMMY_PROJECT_ID = UUID.fromString("3828f4e5-ad0d-402c-978a-e2b9939332c7");
+
+    protected TermIndex<UUID, String> create() {
         return new TermIndex<>(CoreNlpWordTokenizer.create("en"), new NaiveSearchStrategy<>());
     }
 
@@ -27,7 +30,7 @@ public class TermIndexTest {
     @Test
     public void search_ShouldNotIdentifyAcronymsWithDifferentCase() {
         var index = create();
-        index.add("id1", "CAN");
+        index.add(DUMMY_PROJECT_ID, "id1", "CAN");
 
         assertTokenIdMatched(Set.of(), index.match("I can confirm the topic of today"));
     }
@@ -35,7 +38,7 @@ public class TermIndexTest {
     @Test
     public void search_ShouldIdentifyAcronyms() {
         var index = create();
-        index.add("id1", "CAN");
+        index.add(DUMMY_PROJECT_ID, "id1", "CAN");
 
         assertTokenIdMatched(Set.of("id1"), index.match("The topic of today is CAN"));
     }
@@ -43,7 +46,7 @@ public class TermIndexTest {
     @Test
     public void search_ShouldFindHyphenDelimitedTokens() {
         var index = create();
-        index.add("id1", "UAN-30");
+        index.add(DUMMY_PROJECT_ID, "id1", "UAN-30");
 
         assertTokenIdMatched(Set.of("id1"), index.match("UAN 30%"));
     }
@@ -51,8 +54,8 @@ public class TermIndexTest {
     @Test
     public void search_ShouldFindSlashDelimitedConcepts() {
         var index = create();
-        index.add("id1", "Ammonium Nitrate");
-        index.add("id2", "CAN");
+        index.add(DUMMY_PROJECT_ID, "id1", "Ammonium Nitrate");
+        index.add(DUMMY_PROJECT_ID, "id2", "CAN");
 
         assertTokenIdMatched(Set.of("id1", "id2"), index.match("Ammonium Nitrate/CAN"));
     }
@@ -60,8 +63,8 @@ public class TermIndexTest {
     @Test
     public void search_SupportsDuplicateValues() {
         var index = create();
-        index.add("id1", "finished steel");
-        index.add("id2", "finished steel");
+        index.add(DUMMY_PROJECT_ID, "id1", "finished steel");
+        index.add(DUMMY_PROJECT_ID, "id2", "finished steel");
 
         assertTokenIdMatched(Set.of("id1", "id2"), index.match("finished steel"));
     }
@@ -69,8 +72,8 @@ public class TermIndexTest {
 //    @Test
     public void search_DoesntGreedyMatch() {
         var index = create();
-        index.add("id1", "steel");
-        index.add("id2", "steel girder");
+        index.add(DUMMY_PROJECT_ID, "id1", "steel");
+        index.add(DUMMY_PROJECT_ID, "id2", "steel girder");
 
         assertTokenIdMatched(Set.of("id1"), index.match("steel"));
     }
@@ -78,7 +81,7 @@ public class TermIndexTest {
     @Test
     public void search_StopsAtSentenceBoundary() {
         var index = create();
-        index.add("id1", "finished steel");
+        index.add(DUMMY_PROJECT_ID, "id1", "finished steel");
 
         assertTokenIdMatched(Set.of(), index.match("a sentence is finished. steel."));
     }

--- a/taxonomy-manager-rest-server/src/integrationTest/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptDaoTests.java
+++ b/taxonomy-manager-rest-server/src/integrationTest/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptDaoTests.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.sql.DataSource;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -54,7 +53,7 @@ public class ConceptDaoTests {
         var dao = new ConceptDao(dataSource);
         var uuid = UUID.fromString("3828f4e5-ad0d-402c-978a-e2b9939332c7");
 
-        var record = new ConceptRecord(uuid);
+        var record = new ConceptRecord(uuid, 1L);
         var expectedLabels = ArrayListMultimap.<String, String>create();
         expectedLabels.put("en", "value");
 
@@ -72,7 +71,7 @@ public class ConceptDaoTests {
     public void shouldUpdateLabels(@SuppressWarnings("unused") String name, LabelSetter setter, LabelGetter getter) {
         var dao = new ConceptDao(dataSource);
         var uuid = UUID.fromString("3828f4e5-ad0d-402c-978a-e2b9939332c7");
-        var record = new ConceptRecord(uuid);
+        var record = new ConceptRecord(uuid, 1L);
         var label = ArrayListMultimap.<String, String>create();
         label.put("en", "value");
 
@@ -101,26 +100,26 @@ public class ConceptDaoTests {
         var uuidB = UUID.fromString("f0ea2717-1114-46f4-bc51-a25985571a01");
         var relationships = List.of(new ConceptRelationshipRecord(uuidA, uuidB, null, ConceptRelationshipType.BROADER, false));
 
-        dao.storeDataSet(new ConceptDataSet(new ConceptRecord(uuidB)));
-        dao.storeDataSet(new ConceptDataSet(new ConceptRecord(uuidA), relationships));
+        dao.storeDataSet(new ConceptDataSet(new ConceptRecord(uuidB, 1L)));
+        dao.storeDataSet(new ConceptDataSet(new ConceptRecord(uuidA, 1L), relationships));
 
         Assertions.assertEquals(relationships, dao.loadDataSet(uuidA).orElseThrow().getRelationshipRecords());
     }
 
     @Test
     public void search_ShouldRetrieveConceptsByPartialLabel() {
-        var one = new ConceptRecord(UUID.randomUUID());
+        var one = new ConceptRecord(UUID.randomUUID(), 1L);
         one.getPreferredLabel().put("en", "one");
         one.getPreferredLabel().put("fr", "un");
 
-        var two = new ConceptRecord(UUID.randomUUID());
+        var two = new ConceptRecord(UUID.randomUUID(), 1L);
         two.getPreferredLabel().put("en", "two");
 
-        var eleven = new ConceptRecord(UUID.randomUUID());
+        var eleven = new ConceptRecord(UUID.randomUUID(), 1L);
         eleven.getPreferredLabel().put("en", "eleven");
         eleven.getAltLabel().put("fr", "onze");
 
-        var hundred = new ConceptRecord(UUID.randomUUID());
+        var hundred = new ConceptRecord(UUID.randomUUID(), 1L);
         hundred.getPreferredLabel().put("en", "a hundred");
         hundred.getHiddenLabel().put("en", "one hundred");
 

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/analysis/TextAnalyzer.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/analysis/TextAnalyzer.java
@@ -25,7 +25,7 @@ public class TextAnalyzer {
     private static final Logger logger = Logger.getLogger(TextAnalyzer.class.getName());
 
     @Inject
-    TermIndex<UUID> termIndex;
+    TermIndex<String, UUID> termIndex;
 
     @Inject
     RdfModelFactory modelFactory;
@@ -41,9 +41,12 @@ public class TextAnalyzer {
      * @return A list of {@link ConceptModel}s appearing as tags.
      */
     public CollectionModel tagDocument(TextAnalysisInput input) {
-        logger.debug(input.getText());
+        String text = input.getText();
+        logger.debug(text);
 
-        var matches = termIndex.match(input.getText())
+        var matches = input.getProjectId()
+                .map(id -> termIndex.match(id, text))
+                .orElseGet(() -> termIndex.match(text))
                 .stream()
                 .collect(Collectors.groupingBy(TermMatch::getId));
 

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/config/RdfConfig.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/config/RdfConfig.java
@@ -1,14 +1,37 @@
 package com.digirati.taxman.rest.server.infrastructure.config;
 
+import com.digirati.taxman.common.rdf.PersistentProjectScopedModel;
+import com.digirati.taxman.common.rdf.RdfModel;
+import com.digirati.taxman.common.rdf.RdfModelCreationListener;
 import com.digirati.taxman.common.rdf.RdfModelFactory;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import org.apache.jena.rdf.model.Resource;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
+import java.util.List;
+import java.util.UUID;
 
 @ApplicationScoped
 public class RdfConfig {
+    public static void decorateProjectScopedModels(RdfModel model, Resource resource, Multimap<String, String> attributes) {
+        if (!(model instanceof PersistentProjectScopedModel) || !attributes.containsKey("X-Project-Id")) {
+            return;
+        }
+
+        var projectIdValue = Iterables.getOnlyElement(attributes.get("X-Project-Id"));
+        var projectId = UUID.fromString(projectIdValue);
+        var projectScopedModel = (PersistentProjectScopedModel) model;
+
+        projectScopedModel.setProjectId(projectId);
+    }
+
+
     @Produces
     public RdfModelFactory rdfModelFactory() {
-        return new RdfModelFactory();
+        return new RdfModelFactory(List.of(
+                RdfConfig::decorateProjectScopedModels
+        ));
     }
 }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/config/RdfConfig.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/config/RdfConfig.java
@@ -10,21 +10,26 @@ import org.apache.jena.rdf.model.Resource;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
+import javax.ws.rs.WebApplicationException;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 @ApplicationScoped
 public class RdfConfig {
     public static void decorateProjectScopedModels(RdfModel model, Resource resource, Multimap<String, String> attributes) {
-        if (!(model instanceof PersistentProjectScopedModel) || !attributes.containsKey("X-Project-Id")) {
+        if (!(model instanceof PersistentProjectScopedModel) || !attributes.containsKey("X-Project-Slug")) {
             return;
         }
 
-        var projectIdValue = Iterables.getOnlyElement(attributes.get("X-Project-Id"));
-        var projectId = UUID.fromString(projectIdValue);
-        var projectScopedModel = (PersistentProjectScopedModel) model;
+        try {
+            var projectIdValue = Iterables.getOnlyElement(attributes.get("X-Project-Slug"));
+            var projectScopedModel = (PersistentProjectScopedModel) model;
 
-        projectScopedModel.setProjectId(projectId);
+            projectScopedModel.setProjectId(projectIdValue);
+        } catch (NoSuchElementException ex) {
+            throw new WebApplicationException("X-Project-Slug must be present in the request headers");
+        }
     }
 
 

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/config/TaxonomyIndexConfig.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/config/TaxonomyIndexConfig.java
@@ -17,7 +17,7 @@ public class TaxonomyIndexConfig {
 
     @Produces
     @Singleton
-    public TermIndex<UUID> termIndex() {
-        return new TermIndex<>(CoreNlpWordTokenizer.create(languageKey), new NaiveSearchStrategy<>());
+    public TermIndex<String, UUID> termIndex() {
+        return new TermIndex<String, UUID>(CoreNlpWordTokenizer.create(languageKey), new NaiveSearchStrategy<>());
     }
 }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/diagnostics/Rfc7807WebApplicationExceptionMapper.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/diagnostics/Rfc7807WebApplicationExceptionMapper.java
@@ -18,6 +18,7 @@ public final class Rfc7807WebApplicationExceptionMapper
     @Override
     public Response toResponse(WebApplicationException exception) {
         logger.error(exception.getMessage(), exception);
+
         var response = exception.getResponse();
         var type = response.getStatusInfo();
 

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/event/ConceptChangeEvent.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/event/ConceptChangeEvent.java
@@ -6,17 +6,23 @@ import java.util.UUID;
 
 public class ConceptChangeEvent implements Serializable {
     private final UUID uuid;
+    private final String projectId;
     private final List<String> added;
     private final List<String> removed;
 
-    public ConceptChangeEvent(UUID uuid, List<String> added, List<String> removed) {
+    public ConceptChangeEvent(UUID uuid, String projectId, List<String> added, List<String> removed) {
         this.uuid = uuid;
+        this.projectId = projectId;
         this.added = added;
         this.removed = removed;
     }
 
     public UUID getUuid() {
         return uuid;
+    }
+
+    public String getProjectId() {
+        return projectId;
     }
 
     public List<String> getAdded() {

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/media/reader/TypedRdfModelMessageBodyReader.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/media/reader/TypedRdfModelMessageBodyReader.java
@@ -6,6 +6,7 @@ import com.digirati.taxman.common.rdf.RdfModelFactory;
 import com.digirati.taxman.common.rdf.RdfModelFormat;
 import com.digirati.taxman.common.rdf.io.RdfModelReader;
 import com.digirati.taxman.rest.MediaTypes;
+import com.google.common.collect.HashMultimap;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
@@ -61,7 +62,8 @@ public class TypedRdfModelMessageBodyReader implements MessageBodyReader<RdfMode
             throw new NoContentException("No content available in request body");
         }
 
-        pushbackStream.unread(read);
+        var attributes = HashMultimap.<String, String>create();
+        httpHeaders.forEach(attributes::putAll);
 
         RdfModelFormat format;
         if (mediaType.isCompatible(MediaTypes.APPLICATION_RDF_XML)) {
@@ -74,7 +76,7 @@ public class TypedRdfModelMessageBodyReader implements MessageBodyReader<RdfMode
 
         RdfModelReader reader = new RdfModelReader(modelFactory);
         try {
-            return reader.read(type, format, pushbackStream);
+            return reader.read(type, format, pushbackStream, attributes);
         } catch (RdfModelException e) {
             throw new WebApplicationException(e);
         }

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/media/reader/TypedRdfModelMessageBodyReader.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/media/reader/TypedRdfModelMessageBodyReader.java
@@ -8,6 +8,7 @@ import com.digirati.taxman.common.rdf.io.RdfModelReader;
 import com.digirati.taxman.rest.MediaTypes;
 import com.google.common.collect.HashMultimap;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -27,18 +28,11 @@ import java.lang.reflect.Type;
  * provided RDF was well formed.
  */
 @Provider
+@ApplicationScoped
 public class TypedRdfModelMessageBodyReader implements MessageBodyReader<RdfModel> {
 
-    private final RdfModelFactory modelFactory;
-
-    public TypedRdfModelMessageBodyReader() {
-        this(new RdfModelFactory());
-    }
-
     @Inject
-    public TypedRdfModelMessageBodyReader(RdfModelFactory modelFactory) {
-        this.modelFactory = modelFactory;
-    }
+    RdfModelFactory modelFactory;
 
     @Override
     public boolean isReadable(

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/media/reader/TypedRdfModelMessageBodyReader.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/infrastructure/media/reader/TypedRdfModelMessageBodyReader.java
@@ -62,6 +62,8 @@ public class TypedRdfModelMessageBodyReader implements MessageBodyReader<RdfMode
             throw new NoContentException("No content available in request body");
         }
 
+        pushbackStream.unread(read);
+
         var attributes = HashMultimap.<String, String>create();
         httpHeaders.forEach(attributes::putAll);
 

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/mapper/ConceptMapper.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/mapper/ConceptMapper.java
@@ -86,7 +86,7 @@ public class ConceptMapper {
     public ConceptDataSet map(ConceptModel model) {
         final UUID uuid = model.getUuid();
 
-        var record = new ConceptRecord(uuid);
+        var record = new ConceptRecord(uuid, model.getProjectId());
         record.setSource(model.getSource());
         record.setPreferredLabel(model.getPreferredLabel());
         record.setAltLabel(model.getAltLabel());

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptDao.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptDao.java
@@ -108,7 +108,7 @@ public class ConceptDao {
      */
     public void storeDataSet(ConceptDataSet dataset) {
         var record = dataset.getRecord();
-
+System.out.println();
         Object[] recordArgs = {
             record.getUuid(),
             record.getProjectId(),

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptDao.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/ConceptDao.java
@@ -111,6 +111,7 @@ public class ConceptDao {
 
         Object[] recordArgs = {
             record.getUuid(),
+            record.getProjectId(),
             record.getSource(),
             DaoUtils.createRdfPlainLiteral(record.getPreferredLabel()),
             DaoUtils.createRdfPlainLiteral(record.getAltLabel()),
@@ -126,9 +127,10 @@ public class ConceptDao {
 
         int[] recordTypes = new int[recordArgs.length];
         Arrays.fill(recordTypes, Types.OTHER);
+        recordTypes[1] = Types.VARCHAR;
 
         // @FIXME gtierney: 12 positional parameters is garbage. Fix this sometime.
-        jdbcTemplate.update("CALL update_concept(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", recordArgs, recordTypes);
+        jdbcTemplate.update("CALL update_concept(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", recordArgs, recordTypes);
 
         int[] relationTypes = {Types.OTHER, Types.VARCHAR, Types.OTHER};
         Object[] relationArgs = {record.getUuid(), record.getSource(), dataset.getRelationshipRecordsJson()};

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/record/ConceptRecord.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/record/ConceptRecord.java
@@ -6,7 +6,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
-import java.util.HashMap;
 import java.util.UUID;
 
 /**
@@ -14,6 +13,7 @@ import java.util.UUID;
  */
 public class ConceptRecord implements Concept {
     private final UUID uuid;
+    private final String projectId;
 
     private String source;
     private Multimap<String, String> preferredLabel = ArrayListMultimap.create();
@@ -27,8 +27,14 @@ public class ConceptRecord implements Concept {
     private Multimap<String, String> scopeNote = ArrayListMultimap.create();
     private Multimap<String, String> definition = ArrayListMultimap.create();
 
-    public ConceptRecord(UUID uuid) {
+    public ConceptRecord(UUID uuid, String projectId) {
         this.uuid = uuid;
+        this.projectId = projectId;
+    }
+
+    @Override
+    public String getProjectId() {
+        return projectId;
     }
 
     @Override

--- a/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/record/mapper/ConceptRecordMapper.java
+++ b/taxonomy-manager-rest-server/src/main/java/com/digirati/taxman/rest/server/taxonomy/storage/record/mapper/ConceptRecordMapper.java
@@ -10,7 +10,10 @@ import java.util.UUID;
 public class ConceptRecordMapper implements RowMapper<ConceptRecord> {
     @Override
     public ConceptRecord mapRow(ResultSet rs, int rowNum) throws SQLException {
-        ConceptRecord record = new ConceptRecord(rs.getObject("uuid", UUID.class));
+        ConceptRecord record = new ConceptRecord(
+                rs.getObject("uuid", UUID.class),
+                rs.getString("project_slug")
+        );
 
         record.setSource(rs.getString("source"));
         record.setPreferredLabel(ResultSetUtils.getPlainLiteralMap(rs, "preferred_label"));

--- a/taxonomy-manager-rest-server/src/main/resources/db/migration/V11__project_scoping.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/migration/V11__project_scoping.sql
@@ -1,0 +1,34 @@
+INSERT INTO project (slug, title) VALUES ('orphaned-project', '{"en": "Default project for ophaned resources"}');
+
+ALTER TABLE skos_concept_scheme
+    ADD COLUMN project_id bigint null;
+
+UPDATE skos_concept_scheme AS cs
+SET project_id = pscs.project_id
+FROM project_skos_concept_scheme pscs
+WHERE pscs.concept_scheme_id = cs.id;
+
+UPDATE skos_concept_scheme AS cs
+SET project_id = (SELECT id from project WHERE slug = 'orphaned-project')
+WHERE cs.project_id IS NULL;
+
+ALTER TABLE skos_concept ADD COLUMN project_id BIGINT NULL;
+
+UPDATE skos_concept AS c
+SET project_id = cs.project_id
+FROM skos_concept_scheme cs,
+     skos_concept_scheme_concept cs_c
+WHERE cs_c.concept_id = c.id
+  AND cs.id = cs_c.concept_scheme_id;
+
+UPDATE skos_concept AS c
+SET project_id = (SELECT id from project WHERE slug = 'orphaned-project')
+WHERE c.project_id IS NULL;
+
+ALTER TABLE skos_concept ALTER COLUMN project_id SET NOT NULL;
+
+DROP TABLE project_skos_concept_scheme;
+
+CREATE VIEW project_skos_concept_scheme AS
+SELECT cs.project_id, cs.id AS concept_scheme_id
+FROM skos_concept_scheme cs;

--- a/taxonomy-manager-rest-server/src/main/resources/db/migration/V12__project_slug.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/migration/V12__project_slug.sql
@@ -1,0 +1,5 @@
+create or replace view skos_concept_ex as
+select c.*, p.slug as project_slug
+from skos_concept c
+inner join project p on p.id = c.project_id
+where c.deleted = false;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__skos_concept_ex_view.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__skos_concept_ex_view.sql
@@ -1,2 +1,5 @@
 create or replace view skos_concept_ex as
-select * from skos_concept where deleted = false;
+select c.*, p.slug as project_slug
+from skos_concept c
+inner join project p on p.id = c.project_id
+where c.deleted = false;

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__update_concept.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept/R__update_concept.sql
@@ -2,6 +2,7 @@ DROP PROCEDURE IF exists update_concept;
 DROP FUNCTION IF EXISTS update_concept;
 
 CREATE OR REPLACE PROCEDURE update_concept(_uuid uuid,
+                                           _projectslug varchar,
                                            _source varchar,
                                            _preferred_label jsonb,
                                            _alt_label jsonb,
@@ -43,6 +44,7 @@ BEGIN
         BEGIN
             INSERT INTO skos_concept AS c (
                                           uuid,
+                                          project_id,
                                           source,
                                           preferred_label,
                                           alt_label,
@@ -56,6 +58,7 @@ BEGIN
                                           definition)
             VALUES (
                    _uuid,
+                   (SELECT id FROM project WHERE slug = _projectslug),
                    _source,
                    _preferred_label,
                    _alt_label,
@@ -85,6 +88,7 @@ BEGIN
                 BEGIN
                     INSERT INTO skos_concept AS c (
                                                   uuid,
+                                                  project_id,
                                                   source,
                                                   preferred_label,
                                                   alt_label,
@@ -98,6 +102,7 @@ BEGIN
                                                   definition)
                     VALUES (
                            _uuid,
+                           (SELECT id FROM project WHERE slug = _projectslug),
                            _source,
                            _preferred_label,
                            _alt_label,

--- a/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_semantic_relation/R__update_concept_semantic_relations.sql
+++ b/taxonomy-manager-rest-server/src/main/resources/db/procedures/skos_concept_semantic_relation/R__update_concept_semantic_relations.sql
@@ -5,7 +5,7 @@ create procedure update_concept_semantic_relations(_uuid uuid, _source character
 as
 $$
 -- If there are any relations that we don't have database records for yet, create them.
-INSERT INTO skos_concept_ex (uuid, source)
+INSERT INTO skos_concept (uuid, source)
 SELECT (data ->> 'target_id')::uuid, (data ->> 'target_source')::varchar
 FROM jsonb_array_elements(_relations) data
          LEFT JOIN skos_concept_ex sc ON sc.uuid = (data ->> 'target_id')::uuid

--- a/taxonomy-manager-rest/src/main/java/com/digirati/taxman/rest/analysis/TextAnalysisInput.java
+++ b/taxonomy-manager-rest/src/main/java/com/digirati/taxman/rest/analysis/TextAnalysisInput.java
@@ -1,7 +1,10 @@
 package com.digirati.taxman.rest.analysis;
 
+import java.util.Optional;
+
 public class TextAnalysisInput {
     private String text;
+    private String projectId;
 
     public String getText() {
         return text;
@@ -9,5 +12,13 @@ public class TextAnalysisInput {
 
     public void setText(String text) {
         this.text = text;
+    }
+
+    public Optional<String> getProjectId() {
+        return Optional.ofNullable(projectId);
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
     }
 }


### PR DESCRIPTION
Adds a creation listener that tacks on the project ID if present in a request to any `RdfModel`s that implement `ProjectScopedPersistentModel`. Still needs database changes.